### PR TITLE
Add sign recipe to Justfile for PSBT signing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -117,6 +117,10 @@ send n address:
 descriptors private:
     bitcoin-cli -datadir={{datadir}} -chain={{chain}} -rpcwallet={{wallet}} listdescriptors {{private}}
 
+# sign a PSBT with the wallet
+[group('rpc')]
+sign psbt:
+    bitcoin-cli -datadir={{datadir}} -chain={{chain}} -rpcwallet={{wallet}} walletprocesspsbt '{{psbt}}' true "ALL|ANYONECANPAY"
 # run any bitcoin-cli rpc command
 [group('rpc')]
 rpc *command:


### PR DESCRIPTION
## Summary
Adds a `sign` recipe to simplify PSBT signing workflow during testing.

## Motivation
Currently, signing PSBTs requires manually running `bitcoin-cli walletprocesspsbt` with specific parameters. This is tedious during development and testing.

## Changes
- Added `sign` recipe to Justfile that wraps the Bitcoin Core RPC call with correct sighash parameters

## Usage
```bash
# After creating unsigned PSBT with ddust
UNSIGNED_PSBT=""
SIGNED=$(just wallet=wallet_name sign "$UNSIGNED_PSBT")
just run broadcast "$SIGNED"
```

## Testing
Tested on Bitcoin Core v30.2 with regtest network. Successfully signed and broadcast a dust-spending transaction.

Closes #3 #2 