### PR TITLE
Combine mempool dust spends

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use bdk_redb::Store;
 use bdk_wallet::bitcoin::secp256k1::{All, Secp256k1};
 use bdk_wallet::bitcoin::{
-    Address, Amount, EcdsaSighashType, Network, Psbt, TapSighashType, Transaction,
+    Address, Amount, EcdsaSighashType, Network, Psbt, ScriptBuf, TapSighashType, Transaction, TxIn,
 };
 use bdk_wallet::descriptor::ExtendedDescriptor;
 
@@ -14,7 +14,7 @@ use bdk_wallet::bitcoin::psbt::Input;
 use bdk_wallet::bitcoin::psbt::PsbtParseError;
 use bdk_wallet::bitcoin::script::PushBytesBuf;
 use bdk_wallet::chain::{CanonicalizationParams, CheckPoint};
-use bdk_wallet::{PersistedWallet, Wallet, miniscript, wallet_name_from_descriptor};
+use bdk_wallet::{LocalOutput, PersistedWallet, Wallet, miniscript, wallet_name_from_descriptor};
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -113,34 +113,17 @@ fn main() {
                             }
                         })
                         .collect::<Vec<_>>();
+                    info!("dust: {:?}", dust);
                     if !dust.is_empty() {
                         let mut input_amount: Amount = dust.iter().map(|out| out.txout.value).sum();
                         debug!("fees: {}", &input_amount);
                         let utxos = dust.iter().map(|out| out.outpoint).collect::<Vec<_>>();
                         debug!("utxos: {:?}", &utxos);
-
                         let rpc_client =
                             Client::new(&url, auth.clone()).expect("failed to create rpc client");
-                        let tx_ids = rpc_client
-                            .get_raw_mempool()
-                            .expect("failed to get mempool transaction IDs");
 
-                        let mut unconfirmed_txs: Vec<Transaction> = vec![];
-                        // the new tx will use the first unconfirmed tx's script data
-                        let mut first_found_script: Option<Vec<u8>> = None;
-
-                        // find txs in the mempool that match ddust pattern
-                        for txid in tx_ids {
-                            let tx = rpc_client.get_raw_transaction(&txid, None).unwrap();
-                            if is_ddust_tx(&tx, &first_found_script) {
-                                if first_found_script == None {
-                                    let script_bytes =
-                                        tx.output[0].script_pubkey.as_bytes().to_vec();
-                                    first_found_script = Some(script_bytes);
-                                }
-                                unconfirmed_txs.push(tx);
-                            }
-                        }
+                        let unconfirmed_txs = find_unconfirmed_ddust_txs(&rpc_client);
+                        info!("found {} unconfirmed ddust txs", unconfirmed_txs.len());
 
                         let mut tx_builder = wallet.build_tx();
 
@@ -150,60 +133,74 @@ fn main() {
                             .add_utxos(&utxos)
                             .expect("failed to add dust outpoints");
 
-                        // add inputs of unconfirmed txs
-                        for tx in &unconfirmed_txs {
-                            for input in &tx.input {
-                                let f_outpoint = input.previous_output;
-                                let f_input_prev_tx = rpc_client
-                                    .get_raw_transaction(&f_outpoint.txid, None)
-                                    .unwrap();
-                                let f_prev_txout =
-                                    f_input_prev_tx.output[f_outpoint.vout as usize].clone();
+                        if !unconfirmed_txs.is_empty()
+                            && should_combine(
+                                &rpc_client,
+                                input_amount,
+                                &unconfirmed_txs,
+                                &dust,
+                                &unconfirmed_txs[0].output[0].script_pubkey,
+                            )
+                        {
+                            info!("unconfirmed trs can be combined");
+                            // add inputs of unconfirmed txs
+                            for tx in &unconfirmed_txs {
+                                for input in &tx.input {
+                                    let f_outpoint = input.previous_output;
+                                    let f_input_prev_tx = rpc_client
+                                        .get_raw_transaction(&f_outpoint.txid, None)
+                                        .unwrap();
+                                    let f_prev_txout =
+                                        f_input_prev_tx.output[f_outpoint.vout as usize].clone();
 
-                                input_amount += f_prev_txout.value;
+                                    input_amount += f_prev_txout.value;
 
-                                let mut f_psbt_input = Input::default();
-                                // p2tr sighash algorithm commits to all input amounts, thus
-                                // non_witness_utxo is not needed to verify the input value
-                                if f_prev_txout.script_pubkey.is_p2tr() {
-                                    f_psbt_input.witness_utxo = Some(f_prev_txout);
-                                } else {
-                                    f_psbt_input.non_witness_utxo = Some(f_input_prev_tx.clone());
+                                    let mut f_psbt_input = Input::default();
+                                    // p2tr sighash algorithm commits to all input amounts, thus
+                                    // non_witness_utxo is not needed to verify the input value
+                                    if f_prev_txout.script_pubkey.is_p2tr() {
+                                        f_psbt_input.witness_utxo = Some(f_prev_txout);
+                                    } else {
+                                        f_psbt_input.non_witness_utxo =
+                                            Some(f_input_prev_tx.clone());
+                                    }
+                                    f_psbt_input.final_script_witness = Some(input.witness.clone());
+                                    tx_builder
+                                        .add_foreign_utxo_with_sequence(
+                                            f_outpoint,
+                                            f_psbt_input,
+                                            input.segwit_weight(),
+                                            input.sequence,
+                                        )
+                                        .unwrap_or_else(|_| {
+                                            panic!(
+                                                "failed to add the foreign UTXO. Outpoint: {}",
+                                                f_outpoint
+                                            )
+                                        });
                                 }
-                                f_psbt_input.final_script_witness = Some(input.witness.clone());
-                                tx_builder
-                                    .add_foreign_utxo_with_sequence(
-                                        f_outpoint,
-                                        f_psbt_input,
-                                        input.segwit_weight(),
-                                        input.sequence,
-                                    )
-                                    .expect(&format!(
-                                        "failed to add the foreign UTXO. Outpoint: {}",
-                                        f_outpoint
-                                    ));
                             }
                         }
-
+                        debug!("combined fees: {}", &input_amount);
                         tx_builder.fee_absolute(input_amount);
 
-                        // add op_return with data if single input so Tx is 65vb
-                        if unconfirmed_txs.is_empty() && dust.len() == 1 {
-                            let data = PushBytesBuf::try_from("ash".as_bytes().to_vec()).unwrap();
+                        if !unconfirmed_txs.is_empty() {
+                            // the new tx shall use the data found in the unconfirmed txs
+                            let suggested_script = &unconfirmed_txs[0].output[0].script_pubkey;
+                            let op_return = match suggested_script.as_bytes() {
+                                // empty OP_RETURN no data
+                                [0x6a, 0x00] => vec![],
+                                // skip 0x6a (OP_RETURN) and push byte
+                                [0x6a, _, rest @ ..] => rest.to_vec(),
+                                _ => vec![],
+                            };
+                            let data = PushBytesBuf::try_from(op_return).unwrap();
                             tx_builder.add_data(&data);
-                        }
-                        // otherwise op_return with no data or same data as found in the  first
-                        // unconfirmed tx
-                        else {
-                            if let Some(script_bytes) = first_found_script {
-                                let op_return = match script_bytes.as_slice() {
-                                    // empty OP_RETURN no data
-                                    [0x6a] => vec![],
-                                    // skip 0x6a (OP_RETURN) and push byte
-                                    [0x6a, _, rest @ ..] => rest.to_vec(),
-                                    _ => vec![],
-                                };
-                                let data = PushBytesBuf::try_from(op_return).unwrap();
+                        } else {
+                            // add op_return with data if single witness input, so Tx is 65vb
+                            if dust.len() == 1 && dust[0].txout.script_pubkey.is_witness_program() {
+                                let data =
+                                    PushBytesBuf::try_from("ash".as_bytes().to_vec()).unwrap();
                                 tx_builder.add_data(&data);
                             } else {
                                 let data = PushBytesBuf::try_from(vec![]).unwrap();
@@ -220,8 +217,6 @@ fn main() {
 
                         let psbt = tx_builder.finish().expect("failed to create psbt");
                         info!("sign and broadcast tx for psbt: {}", psbt);
-                    } else {
-                        info!("no dust found");
                     }
                 } else {
                     error!("could not load wallet with name {}", wallet_name);
@@ -473,6 +468,30 @@ fn wallet_names(db: Arc<Database>) -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
+fn find_unconfirmed_ddust_txs(rpc_client: &Client) -> Vec<Transaction> {
+    let tx_ids = rpc_client
+        .get_raw_mempool()
+        .expect("failed to get mempool transaction IDs");
+
+    let mut unconfirmed_txs: Vec<Transaction> = vec![];
+    // the combined tx shall use the first unconfirmed tx's script data
+    let mut first_found_script: Option<Vec<u8>> = None;
+
+    // find txs in the mempool that match ddust pattern
+    for txid in tx_ids {
+        let tx = rpc_client.get_raw_transaction(&txid, None).unwrap();
+        if is_ddust_tx(&tx, &first_found_script) {
+            if first_found_script.is_none() {
+                let script_bytes = tx.output[0].script_pubkey.as_bytes().to_vec();
+                first_found_script = Some(script_bytes);
+            }
+            unconfirmed_txs.push(tx);
+        }
+    }
+
+    unconfirmed_txs
+}
+
 /// ddust pattern:
 /// has a single op_return
 /// one or more inputs with SIGHASH_ALL|ANYONECANPAY signature type
@@ -494,7 +513,7 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
     let is_dust_disposal = if let Some(existing_script) = want_script {
         script_bytes == existing_script.as_slice()
     } else {
-        script_bytes == [0x6a] || script_bytes == [0x6a, 0x03, 0x61, 0x73, 0x68]
+        script_bytes == [0x6a, 0x00] || script_bytes == [0x6a, 0x03, 0x61, 0x73, 0x68]
     };
 
     if !is_dust_disposal {
@@ -502,8 +521,6 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
     }
 
     // All inputs must be ANYONECANPAY|ALL
-    const SIGHASH_ANYONECANPAY_ALL: u8 = 0x81;
-
     for input in &tx.input {
         if input.witness.is_empty() {
             return false;
@@ -514,13 +531,13 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
         match sig.len() {
             // Taproot with explicit sighash
             65 => {
-                if sig[64] != SIGHASH_ANYONECANPAY_ALL {
+                if sig[64] != TapSighashType::AllPlusAnyoneCanPay as u8 {
                     return false;
                 }
             }
             // ECDSA (P2WPKH/P2WSH)
             71..=73 => {
-                if *sig.last().unwrap() != SIGHASH_ANYONECANPAY_ALL {
+                if *sig.last().unwrap() != EcdsaSighashType::AllPlusAnyoneCanPay as u8 {
                     return false;
                 }
             }
@@ -530,4 +547,84 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
     }
 
     true
+}
+
+fn get_input_vsize(input: &TxIn) -> f64 {
+    let weight = input.base_size() * 3 + input.total_size();
+    weight as f64 / 4.0
+}
+
+fn estimate_input_vsize(script_pubkey: &ScriptBuf) -> f64 {
+    if script_pubkey.is_p2tr() {
+        57.5
+    } else if script_pubkey.is_p2wpkh() {
+        68.0
+    } else if script_pubkey.is_p2wsh() {
+        // 2-of-3 multisig estimate
+        105.0
+    } else if script_pubkey.is_p2pkh() {
+        148.0
+    } else if script_pubkey.is_p2sh() {
+        // Could be P2SH-P2WPKH (~364 WU)
+        // Could be P2SH-P2WSH (~478 WU for 2-of-3)
+        // Could be bare P2SH multisig (~1188 WU for 2-of-3)
+        // Can't tell from scriptPubKey alone, use worst case
+        297.0
+    } else {
+        panic!("Unsupported input encountered");
+    }
+}
+
+/// Checks if combining dust inputs with existing ddust transactions in the mempool
+/// produces a fee rate at least 1 sat/vB higher than the highest existing fee rate,
+/// as required by RBF replacement rules.
+fn should_combine(
+    rpc_client: &Client,
+    this_amount: Amount,
+    unconfirmed_txs: &Vec<Transaction>,
+    dust_utxos: &[LocalOutput],
+    output_script: &ScriptBuf,
+) -> bool {
+    // this tx fee rate > max foreign tx fee rate
+    // this tx fee rate = fee / vsize
+    // -> total dust amt / vsize
+    // vsize = overhead + one op_return output + (new dust utxos + foreign utxos)
+    let mut max_fee_rate: f64 = 0.0;
+    let mut tx_vsize: f64 = 0.0;
+    let mut input_amount: Amount = this_amount;
+
+    // overhead size
+    tx_vsize += 10.5;
+    // size of dust inputs to be spent
+    tx_vsize += dust_utxos
+        .iter()
+        .map(|utxo| estimate_input_vsize(&utxo.txout.script_pubkey))
+        .sum::<f64>();
+
+    tx_vsize += match output_script.as_bytes() {
+        // empty OP_RETURN no data, size = 11
+        [0x6a, 0x00] => 11.0,
+        // contains 3 bytes 'ash', size = 14
+        _ => 14.0,
+    };
+
+    for tx in unconfirmed_txs {
+        let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
+        let fee = entry.fees.base;
+        input_amount += fee;
+        let fee_sats = fee.to_sat();
+        let vsize = entry.vsize;
+        let rate = fee_sats as f64 / vsize as f64;
+        if rate > max_fee_rate {
+            max_fee_rate = rate;
+        }
+
+        for input in &tx.input {
+            // foreign utxo input size
+            tx_vsize += get_input_vsize(input);
+        }
+    }
+
+    let tx_fee_rate = input_amount.to_sat() as f64 / tx_vsize;
+    tx_fee_rate > max_fee_rate + 1.0
 }


### PR DESCRIPTION
## Combine mempool dust spends

Fixes [issue#1](https://github.com/bubb1es71/ddust/issues/1) when creating a new dust spend transaction, the spend now scans the mempool for existing ddust transactions and combines inputs to save blockspace.

### How it works

1. Scans the mempool for unconfirmed transactions matching the ddust pattern: single OP_RETURN output (empty or "ash") with all inputs signed using `SIGHASH_ALL|ANYONECANPAY`
2. Adds existing signed inputs as foreign UTXOs to the new transaction, preserving their original signatures and sequence numbers
3. Verifies the combined fee rate exceeds the highest existing fee rate by at least 1 sat/vB (required for RBF replacement)
4. Creates a PSBT with the existing finalized inputs and new unsigned inputs
5. The combined transaction replaces the individual ones in the mempool via RBF

### Why this matters

As proposed by @ ajtowns in the [Delving Bitcoin discussion](https://delvingbitcoin.org/t/disposing-of-dust-attack-utxos/2215/2?u=harris), using `ANYONECANPAY|ALL` allows dust spend transactions to be permissionlessly combined by anyone. Each additional combined input saves ~23 vB of blockspace by sharing transaction overhead and the OP_RETURN output.

### Key details

- The exact output script from the first matched mempool transaction is reused byte-for-byte to preserve signature validity