### PR TITLE
add JSON output to list, spend, and broadcast commands Fixes #6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["bubb1es71 <bubb1es71@proton.me>"]
 license = "MIT"
 
 [dependencies]
+serde_json = "1.0"
 bdk_wallet = "2"
 bdk_bitcoind_rpc = "0.22"
 bdk_redb = "0.1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use bdk_wallet::bitcoin::script::PushBytesBuf;
 use bdk_wallet::chain::{CanonicalizationParams, CheckPoint};
 use bdk_wallet::{LocalOutput, PersistedWallet, Wallet, miniscript, wallet_name_from_descriptor};
 use clap::{Parser, Subcommand, ValueEnum};
+use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -78,10 +79,14 @@ fn main() {
                             let address = Address::from_script(&out.txout.script_pubkey, network)
                                 .expect("failed to get address");
                             let value = out.txout.value.display_dynamic();
-                            info!(
-                                "value: {}, address: {}, outpoint: {}:{}",
-                                value, address, out.outpoint.txid, out.outpoint.vout
-                            );
+                            let output = json!({
+                                "wallet": wallet_name,
+                                "value": value.to_string(),
+                                "address": address.to_string(),
+                                "txid": out.outpoint.txid.to_string(),
+                                "vout": out.outpoint.vout
+                            });
+                            println!("{}", serde_json::to_string_pretty(&output).unwrap());
                         }
                     });
                 } else {
@@ -218,7 +223,10 @@ fn main() {
                         }
 
                         let psbt = tx_builder.finish().expect("failed to create psbt");
-                        info!("sign and broadcast tx for psbt: {}", psbt);
+                        let output = json!({
+                            "psbt": psbt.to_string()
+                        });
+                        println!("{}", serde_json::to_string_pretty(&output).unwrap());
                     }
                 } else {
                     error!("could not load wallet with name {}", wallet_name);
@@ -232,7 +240,10 @@ fn main() {
             let txid = rpc_client
                 .send_raw_transaction(&tx)
                 .expect("failed to broadcast transaction");
-            info!("transaction broadcast with txid: {}", txid);
+            let output = json!({
+                "txid": txid.to_string()
+            });
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
         }
     }
 }


### PR DESCRIPTION
# Add JSON output to commands
 
Fixed #6 by making the command outputs return JSON instead of plain text.
 
Now all commands output structured JSON:
- `list` returns dust UTXOs as JSON objects
- `spend` returns `{"psbt": "..."}`
- `broadcast` returns `{"txid": "..."}`
 
This makes it way easier to use in shell scripts. You can now do stuff like:
```bash
PSBT=$(ddust spend <address> | jq -r '.psbt')
```
 
Tested on regtest with actual dust UTXOs.