### PR TITLE
feat: return simple output values, json for dust list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -31,15 +31,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -317,15 +317,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crunchy"
@@ -341,6 +341,8 @@ dependencies = [
  "bdk_redb",
  "bdk_wallet",
  "clap",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
 ]
@@ -412,9 +414,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jsonrpc"
@@ -436,9 +438,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "log"
@@ -484,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -742,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -801,18 +803,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,7 @@ bdk_wallet = "2"
 bdk_bitcoind_rpc = "0.22"
 bdk_redb = "0.1.1"
 clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3.22"

--- a/Justfile
+++ b/Justfile
@@ -41,7 +41,7 @@ test:
 
 # run the project
 run *command: fmt
-    cargo run -- -v -d {{datadir}} -c {{chain}} {{command}}
+    cargo run -- -d {{datadir}} -c {{chain}} {{command}}
 
 # clean the project target directory
 clean:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use bdk_redb::Store;
 use bdk_wallet::bitcoin::secp256k1::{All, Secp256k1};
 use bdk_wallet::bitcoin::{
-    Address, Amount, EcdsaSighashType, Network, Psbt, ScriptBuf, TapSighashType, Transaction, TxIn,
+    Address, Amount, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf, TapSighashType,
+    Transaction, TxIn,
 };
 use bdk_wallet::descriptor::ExtendedDescriptor;
 
@@ -16,6 +17,7 @@ use bdk_wallet::bitcoin::psbt::PsbtParseError;
 use bdk_wallet::bitcoin::script::Instruction;
 use bdk_wallet::bitcoin::script::PushBytesBuf;
 use bdk_wallet::chain::{CanonicalizationParams, CheckPoint};
+use bdk_wallet::serde::Serialize;
 use bdk_wallet::{LocalOutput, PersistedWallet, Wallet, miniscript, wallet_name_from_descriptor};
 use clap::{Parser, Subcommand, ValueEnum};
 use std::path::{Path, PathBuf};
@@ -34,8 +36,9 @@ fn main() {
     // a builder for `FmtSubscriber`.
     let subscriber = FmtSubscriber::builder()
         // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
-        // will be written to stdout.
+        // will be written to stderr.
         .with_max_level(log_level)
+        .with_writer(std::io::stderr)
         // completes the builder.
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
@@ -46,7 +49,7 @@ fn main() {
     let db_file = args
         .datadir
         .join(format!("ddust-{}.redb", network.to_string().to_lowercase()));
-    info!("db file: {:?}", db_file);
+    debug!("db file: {:?}", db_file);
     let db = Database::create(db_file).expect("failed to open database");
     let db = Arc::new(db);
     let url = default_url(&network);
@@ -67,8 +70,9 @@ fn main() {
             }
         }
         Commands::List => {
+            let mut found_dust = Vec::new();
             for wallet_name in wallet_names(db.clone()) {
-                info!("wallet: {}", wallet_name);
+                debug!("wallet: {}", wallet_name);
                 if let (Some(mut wallet), mut store) =
                     load_wallet(db.clone(), network, wallet_name.clone())
                 {
@@ -76,18 +80,21 @@ fn main() {
                     wallet.list_unspent().for_each(|out| {
                         if is_dust(&out, &dust_amount) {
                             let address = Address::from_script(&out.txout.script_pubkey, network)
-                                .expect("failed to get address");
-                            let value = out.txout.value.display_dynamic();
-                            info!(
-                                "value: {}, address: {}, outpoint: {}:{}",
-                                value, address, out.outpoint.txid, out.outpoint.vout
-                            );
+                                .expect("failed to get address")
+                                .to_string();
+                            let value = out.txout.value.to_sat() as u32;
+                            found_dust.push(Dust {
+                                address,
+                                value,
+                                outpoint: out.outpoint,
+                            });
                         }
                     });
                 } else {
                     error!("could not load wallet with name {}", wallet_name);
                 }
             }
+            println!("{}", serde_json::to_string_pretty(&found_dust).unwrap());
         }
         Commands::Spend { address } => {
             let filter_address = Address::from_str(&address)
@@ -95,7 +102,7 @@ fn main() {
                 .require_network(network)
                 .expect("invalid network");
             for wallet_name in wallet_names(db.clone()) {
-                info!("wallet: {}", wallet_name);
+                debug!("wallet: {}", wallet_name);
                 if let (Some(mut wallet), mut store) =
                     load_wallet(db.clone(), network, wallet_name.clone())
                 {
@@ -118,7 +125,7 @@ fn main() {
                         let mut input_amount: Amount = dust.iter().map(|out| out.txout.value).sum();
                         let utxos = dust.iter().map(|out| out.outpoint).collect::<Vec<_>>();
                         let unconfirmed_txs = find_unconfirmed_ddust_txs(&rpc_client);
-                        info!("found {} unconfirmed ddust txs", unconfirmed_txs.len());
+                        debug!("found {} unconfirmed ddust txs", unconfirmed_txs.len());
 
                         let mut tx_builder = wallet.build_tx();
 
@@ -137,7 +144,7 @@ fn main() {
                                 &unconfirmed_txs[0].output[0].script_pubkey,
                             )
                         {
-                            info!("unconfirmed trs can be combined");
+                            debug!("unconfirmed trs can be combined");
                             // add inputs of unconfirmed txs
                             for tx in &unconfirmed_txs {
                                 for input in &tx.input {
@@ -183,7 +190,7 @@ fn main() {
                                 }
                             }
                         }
-                        info!("total spent to fees: {}", &input_amount);
+                        debug!("total spent to fees: {}", &input_amount);
                         tx_builder.fee_absolute(input_amount);
 
                         if !unconfirmed_txs.is_empty() {
@@ -218,7 +225,7 @@ fn main() {
                         }
 
                         let psbt = tx_builder.finish().expect("failed to create psbt");
-                        info!("sign and broadcast tx for psbt: {}", psbt);
+                        println!("{}", psbt);
                     }
                 } else {
                     error!("could not load wallet with name {}", wallet_name);
@@ -232,7 +239,7 @@ fn main() {
             let txid = rpc_client
                 .send_raw_transaction(&tx)
                 .expect("failed to broadcast transaction");
-            info!("transaction broadcast with txid: {}", txid);
+            println!("{}", txid);
         }
     }
 }
@@ -271,18 +278,25 @@ enum Commands {
         #[arg(short, long, default_value_t = 0)]
         start_height: u32,
     },
-    /// List all dust UTXOs in your wallet descriptor(s)
+    /// List all dust UTXOs in your wallet descriptor(s), returns json array
     List,
-    /// Create a PSBT to spend dust UTXOs for an address to an OP_RETURN, the entire amount will go to fees
+    /// Spend dust UTXOs to an OP_RETURN, the entire amount goes to fees, returns PSBT
     Spend {
         /// Bitcoin address of dust to be spent
         address: String,
     },
-    /// Broadcast a PSBT after it's been signed
+    /// Broadcast a PSBT after it's been signed, returns txid
     Broadcast {
         #[arg(value_parser = parse_psbt)]
         psbt: Psbt,
     },
+}
+
+#[derive(Serialize)]
+struct Dust {
+    pub address: String,
+    pub value: u32,
+    pub outpoint: OutPoint,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -424,17 +438,17 @@ fn create_wallet(
 
 fn sync_wallet(rpc_client: &Client, wallet: &mut PersistedWallet<Store>, store: &mut Store) {
     let blockchain_info = rpc_client.get_blockchain_info().unwrap();
-    info!(
+    debug!(
         "connected to bitcoin core rpc, chain: {}",
         blockchain_info.chain
     );
-    info!(
+    debug!(
         "latest block: {} at height {}",
         blockchain_info.best_block_hash, blockchain_info.blocks,
     );
 
     let wallet_tip: CheckPoint = wallet.latest_checkpoint();
-    info!(
+    debug!(
         "current wallet tip is: {} at height {}",
         &wallet_tip.hash(),
         &wallet_tip.height()
@@ -457,7 +471,7 @@ fn sync_wallet(rpc_client: &Client, wallet: &mut PersistedWallet<Store>, store: 
         expected_mempool_tx,
     );
 
-    info!("syncing blocks...");
+    debug!("syncing blocks...");
     while let Some(block) = emitter.next_block().unwrap() {
         wallet
             .apply_block_connected_to(&block.block, block.block_height(), block.connected_to())
@@ -479,7 +493,7 @@ fn sync_wallet(rpc_client: &Client, wallet: &mut PersistedWallet<Store>, store: 
         }
     }
 
-    info!("syncing mempool...");
+    debug!("syncing mempool...");
     let mempool_emissions: Vec<(Arc<Transaction>, u64)> = emitter.mempool().unwrap().update;
     wallet.apply_unconfirmed_txs(mempool_emissions);
     wallet.persist(store).expect("unable to persist wallet");


### PR DESCRIPTION
fixes #6 

- changed tracing messages to go to *stderr*
- commands now return simple output values
  - `add` returns no output on success
  - `list` returns json array of `Dust` values
  - `spend` returns a PSBT string
  - `broadcast` returns a tx id string 