### PR TITLE
Revert NONE|ANYONECANPAY change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_chain"
-version = "0.23.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290eff038799a8ac0c5a82b6160a9ca456baa299a6f22b262c771342d2846c0"
+checksum = "5b5d691fd092aacec7e05046b7d04897d58d6d65ed3152cb6cf65dababcfabed"
 dependencies = [
  "bdk_core",
  "bitcoin",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_core"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3028782f6bf14a6df987244333d34e6b272b5a40a53e4879ec2dfd82275a3a"
+checksum = "0dbbe4aad0c898bfeb5253c222be3ea3dccfb380a07e72c87e3e4ed6664a6753"
 dependencies = [
  "bitcoin",
  "hashbrown",
@@ -252,9 +252,9 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -507,9 +507,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -912,18 +912,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Justfile
+++ b/Justfile
@@ -141,7 +141,7 @@ descriptors private:
 # sign a PSBT with the wallet
 [group('rpc')]
 sign psbt:
-    bitcoin-cli -datadir={{datadir}} -chain={{chain}} -rpcwallet={{wallet}} walletprocesspsbt '{{psbt}}' true "NONE|ANYONECANPAY"
+    bitcoin-cli -datadir={{datadir}} -chain={{chain}} -rpcwallet={{wallet}} walletprocesspsbt '{{psbt}}' true "ALL|ANYONECANPAY"
 # run any bitcoin-cli rpc command
 [group('rpc')]
 rpc *command:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Options:
 
 ## Mempool Batching
 
-When running `spend`, ddust scans the mempool for existing unconfirmed ddust transactions identified by a single OP_RETURN output and inputs signed with `SIGHASH_NONE|ANYONECANPAY`. If matching transactions are found, ddust checks whether batching them with the new dust inputs would satisfy RBF replacement rules: the combined fee rate must exceed the highest existing ddust transaction fee rate by at least 0.1 sat/vB, and the total absolute fee must be higher than the sum of the replaced transactions' fees.
+When running `spend`, ddust scans the mempool for existing unconfirmed ddust transactions identified by a single OP_RETURN output and inputs signed with sighash `ALL|ANYONECANPAY`. If matching transactions are found, ddust checks whether batching them with the new dust inputs would satisfy RBF replacement rules: the combined fee rate must exceed the highest existing ddust transaction fee rate by at least 0.1 sat/vB.
 
 If the check passes, ddust builds a single replacement transaction that:
 

--- a/docs/bip-dust-disposal.md
+++ b/docs/bip-dust-disposal.md
@@ -70,8 +70,8 @@ A compliant dust disposal transaction MUST satisfy all the following requirement
 #### Inputs
 
 1. All inputs MUST set the nSequence to 0xFFFFFFFF (do not signal for BIP 125 RBF).
-2. All inputs MUST use the signature hash type `NONE|ANYONECANPAY` (0x81).
-3. For Taproot (P2TR) inputs using key-path spending, implementations MUST explicitly append the signature hash type byte `NONE|ANYONECANPAY` (0x81) to enable ANYONECANPAY semantics, as the default sighash for Taproot (SIGHASH_DEFAULT, which omits the byte) does not include ANYONECANPAY.
+2. All inputs MUST use the signature hash type `ALL|ANYONECANPAY` (0x81).
+3. For Taproot (P2TR) inputs using key-path spending, implementations MUST explicitly append the signature hash type byte `ALL|ANYONECANPAY` (0x81) to enable ANYONECANPAY semantics, as the default sighash for Taproot (SIGHASH_DEFAULT, which omits the byte) does not include ANYONECANPAY.
 4. All inputs must be confirmed in the blockchain at least one block deep.
 
 #### Transaction Size
@@ -115,7 +115,7 @@ Multiple unconfirmed dust disposal transactions created by unrelated entities ca
 1. Pre-signed dust inputs MUST be collected from the public bitcoin network mempool.
 2. Inputs MUST NOT be received directly from other wallet users.
 3. The batch creator MUST add a new dust UTXO input to meet the RBF rules requiring an improved fee amount and rate.
-4. The single output MUST be changed to an empty OP_RETURN. The "ash" message is not needed.
+4. All inputs MUST be spent to the same OP_RETURN output, empty or with the `ash` value.
 
 Batch dust disposal transactions must follow all other transaction construction requirements for non-batched dust disposal transactions.
 
@@ -164,18 +164,18 @@ Bitcoin relay policy enforces a minimum transaction base size of 65 bytes to pre
 
 Dust disposal transactions must meet the minimum relay fee rate, which is currently 0.1 sat/vB (Bitcoin Core 28.3, 29.1, 30.0+). This allows dust UTXOs to be disposed of economically even when their value is small. Implementations targeting older node versions may need higher minimum fee rates.
 
-### Why Sighash NONE | ANYONECANPAY?
+### Why Sighash `ALL|ANYONECANPAY`?
 
-The NONE sighash flag means that the signature does not commit to any outputs of the transaction. This means anyone can modify the output of the dust disposal transaction after signing. To use as little block space as possible when batching dust UTXOs, we need to be able to replace an "ash" OP_RETURN output with an empty OP_RETURN. 
+The ALL sighash flag means that the signature commits to all outputs of the transaction. This means signed dust inputs can only be spent to the special OP_RETURN output of a dust disposal transaction.
 
-The ANYONECANPAY sighash flag means that the signature does not commit to any inputs of the transaction. This means anyone can add additional inputs to the dust disposal transaction after signing. When batching dust UTXOs, we do not care which dust UTXOs are spent together as long as they do not associate addresses owned by the same entity.
+The ANYONECANPAY sighash flag means that the signature only commits to the one input being signed. This means anyone can add additional inputs to the dust disposal transaction after signing. When batching dust UTXOs, we do not care which dust UTXOs are spent together as long as they do not associate addresses owned by the same entity.
 
 Together these flags enable:
 
 - **Batching**: A new dust input can be added to an unconfirmed dust disposal transaction found in the mempool and batched together via RBF.
-- **User privacy**: Transactions shared via the public mempool do not reveal user identity metadata.
-- **Fee Bumping**: Additional inputs can be added by unrelated third parties to increase the fee rate.
-- **Efficiency**: An empty OP_RETURN can always be used when adding an input to an existing unconfirmed disposal transaction. 
+- **User privacy**: Dust disposal transactions shared via the public mempool do not reveal user identity metadata.
+- **Fee Bumping**: Additional inputs can be added by unrelated third parties to improve the fee rate.
+- **Limited RBF**: By committing dust inputs to a single `OP_RETURN` output we restrict these inputs to only being spent with other disposal inputs. This limits the number of valid conflicting RBF transactions that can be created and relayed.
 
 ### Why nLockTime block height 0
 
@@ -192,11 +192,11 @@ Together these flags enable:
 
 This BIP introduces no changes to the Bitcoin consensus rules or peer-to-peer protocol. All transactions conforming to this specification are valid under existing consensus rules and can be relayed by nodes supporting:
 
+- Sighash `ALL|ANYONECANPAY` (original Bitcoin feature)
 - OP_RETURN outputs (Bitcoin Core 0.9.0+)
-- SIGHASH_ANYONECANPAY (original Bitcoin feature)
+- RBF (Replace by Fee) BIP 125 (Bitcoin Core 0.12.0+)
 - 0.1 sat/vB minimum relay fee (Bitcoin Core 28.3, 29.1, 30.0+)
 - Private transaction broadcast (Bitcoin Core 31.0+)
-- RBF (Replace by Fee) BIP 125
 
 Nodes that do not relay transactions with fee rates below 1 sat/vB could slow the propagation of disposal transactions with lower fee rates.
 
@@ -209,7 +209,7 @@ The implementation provides:
 - Automatic dust detection based on configurable thresholds
 - Transaction batching via RBF
 - Support for P2PKH, P2SH, P2WPKH, P2WSH, and P2TR input descriptors
-- Integration with Bitcoin Core 30.0+ via RPC for syncing and broadcasting transactions
+- Integration with Bitcoin Core (version 30.0+) via RPC for syncing and broadcasting transactions
 
 ## Test Cases
 
@@ -255,7 +255,7 @@ All valid dust disposal transactions should be verified to be accepted into the 
 ### Batching dust disposal txs via RBF
 
 1. Adding a Bech32m dust input to an unconfirmed disposal transaction with a legacy dust input keeps the original single empty OP_RETURN output.
-2. Adding a Bech32m dust input to an unconfirmed disposal transaction with a Bech32m dust input changes the original single "ash" OP_RETURN output to an empty OP_RETURN output.
+2. Adding a Bech32m dust input to an unconfirmed disposal transaction with a Bech32m dust input keeps the original single "ash" OP_RETURN output.
 3. Adding a new dust input to an unconfirmed disposal transaction results in a new batch disposal transaction with a fee rate sufficient for RBF.
 4. A new dust input that contributes an insufficient amount for RBF with an existing unconfirmed disposal transaction is not batched with it.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,11 +233,11 @@ fn cmd_spend(
                     tx_builder.add_data(&data);
                 }
 
-                // set script type to NONE|ANYONECANPAY
+                // set script type to ALL|ANYONECANPAY
                 if dust[0].txout.script_pubkey.is_p2tr() {
-                    tx_builder.sighash(TapSighashType::NonePlusAnyoneCanPay.into());
+                    tx_builder.sighash(TapSighashType::AllPlusAnyoneCanPay.into());
                 } else {
-                    tx_builder.sighash(EcdsaSighashType::NonePlusAnyoneCanPay.into());
+                    tx_builder.sighash(EcdsaSighashType::AllPlusAnyoneCanPay.into());
                 }
 
                 let psbt = tx_builder.finish().expect("failed to create psbt");
@@ -550,7 +550,7 @@ fn find_unconfirmed_ddust_txs(rpc_client: &Client) -> Vec<Transaction> {
 
 /// ddust pattern:
 /// has a single op_return
-/// one or more inputs with NONE|ANYONECANPAY signature type
+/// one or more inputs with ALL|ANYONECANPAY signature type
 /// op_return: can be empty or contains the string "ash"
 fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
     // Must have exactly one output
@@ -576,7 +576,7 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
         return false;
     }
 
-    // All inputs must be NONE|ANYONECANPAY
+    // All inputs must be ALL|ANYONECANPAY
     for input in &tx.input {
         if !input.witness.is_empty() {
             // If a segwit input check the witness sighash byte
@@ -584,13 +584,13 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
             match sig.len() {
                 // Taproot with explicit sighash
                 65 => {
-                    if sig[64] != TapSighashType::NonePlusAnyoneCanPay as u8 {
+                    if sig[64] != TapSighashType::AllPlusAnyoneCanPay as u8 {
                         return false;
                     }
                 }
                 // ECDSA (P2WPKH/P2WSH)
                 71..=73 => {
-                    if *sig.last().unwrap() != EcdsaSighashType::NonePlusAnyoneCanPay as u8 {
+                    if *sig.last().unwrap() != EcdsaSighashType::AllPlusAnyoneCanPay as u8 {
                         return false;
                     }
                 }
@@ -603,7 +603,7 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
             for instruction in input.script_sig.instructions().flatten() {
                 if let Instruction::PushBytes(data) = instruction
                     && let Ok(sig) = Signature::from_slice(data.as_bytes())
-                    && sig.sighash_type != EcdsaSighashType::NonePlusAnyoneCanPay
+                    && sig.sighash_type != EcdsaSighashType::AllPlusAnyoneCanPay
                 {
                     return false;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,6 @@ fn cmd_spend(
             debug!("dust: {:?}", dust);
             if !dust.is_empty() {
                 let mut input_amount: Amount = dust.iter().map(|out| out.txout.value).sum();
-                let mut num_inputs = dust.len();
                 let utxos = dust.iter().map(|out| out.outpoint).collect::<Vec<_>>();
                 let unconfirmed_txs = find_unconfirmed_ddust_txs(rpc_client);
                 debug!("found {} unconfirmed ddust txs", unconfirmed_txs.len());
@@ -174,7 +173,13 @@ fn cmd_spend(
                     .expect("failed to add dust outpoints");
 
                 if !unconfirmed_txs.is_empty()
-                    && should_batch(rpc_client, input_amount, &unconfirmed_txs, &dust)
+                    && should_batch(
+                        rpc_client,
+                        input_amount,
+                        &unconfirmed_txs,
+                        &dust,
+                        &unconfirmed_txs[0].output[0].script_pubkey,
+                    )
                 {
                     debug!("unconfirmed txs can be batched");
                     for tx in &unconfirmed_txs {
@@ -186,7 +191,6 @@ fn cmd_spend(
                             let f_prev_txout =
                                 f_input_prev_tx.output[f_outpoint.vout as usize].clone();
 
-                            num_inputs += 1;
                             input_amount += f_prev_txout.value;
 
                             let mut f_psbt_input = Input::default();
@@ -223,14 +227,27 @@ fn cmd_spend(
                 info!("total spent to fees: {}", &input_amount);
                 tx_builder.fee_absolute(input_amount);
 
-                // add op_return with data if single witness input, so Tx is 65vb
-
-                if num_inputs == 1 && dust[0].txout.script_pubkey.is_witness_program() {
-                    let data = PushBytesBuf::try_from("ash".as_bytes().to_vec()).unwrap();
+                if !unconfirmed_txs.is_empty() {
+                    // the new tx shall use the data found in the unconfirmed txs
+                    let suggested_script = &unconfirmed_txs[0].output[0].script_pubkey;
+                    let op_return = match suggested_script.as_bytes() {
+                        // empty OP_RETURN no data
+                        [0x6a, 0x00] => vec![],
+                        // skip 0x6a (OP_RETURN) and push byte
+                        [0x6a, _, rest @ ..] => rest.to_vec(),
+                        _ => vec![],
+                    };
+                    let data = PushBytesBuf::try_from(op_return).unwrap();
                     tx_builder.add_data(&data);
                 } else {
-                    let data = PushBytesBuf::try_from(vec![]).unwrap();
-                    tx_builder.add_data(&data);
+                    // add op_return with data if single witness input, so Tx is 65vb
+                    if dust.len() == 1 && dust[0].txout.script_pubkey.is_witness_program() {
+                        let data = PushBytesBuf::try_from("ash".as_bytes().to_vec()).unwrap();
+                        tx_builder.add_data(&data);
+                    } else {
+                        let data = PushBytesBuf::try_from(vec![]).unwrap();
+                        tx_builder.add_data(&data);
+                    }
                 }
 
                 // set script type to ALL|ANYONECANPAY
@@ -598,10 +615,10 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
                 _ => return false,
             }
         }
-        // If a legacy input, check the script sig sighash byte
+        // If a legacy, input check the script sig sighash byte
         else if input.script_sig.is_p2pkh() || input.script_sig.is_p2sh() {
-            for instruction in input.script_sig.instructions().flatten() {
-                if let Instruction::PushBytes(data) = instruction
+            for instruction in input.script_sig.instructions() {
+                if let Ok(Instruction::PushBytes(data)) = instruction
                     && let Ok(sig) = Signature::from_slice(data.as_bytes())
                     && sig.sighash_type != EcdsaSighashType::AllPlusAnyoneCanPay
                 {
@@ -645,13 +662,14 @@ fn is_dust(out: &LocalOutput, dust_amount: &Amount) -> bool {
 }
 
 /// Checks if batching dust inputs with existing ddust transactions in the mempool
-/// produces a fee rate at least 0.1 sat/vB higher than the highest existing fee rate,
+/// produces a fee rate at least 0.01 sat/vB higher than the highest existing fee rate,
 /// as required by RBF replacement rules.
 fn should_batch(
     rpc_client: &Client,
     this_amount: Amount,
     unconfirmed_txs: &Vec<Transaction>,
     dust_utxos: &[LocalOutput],
+    output_script: &ScriptBuf,
 ) -> bool {
     // this tx fee rate > max foreign tx fee rate
     // this tx fee rate = fee / vsize
@@ -669,8 +687,12 @@ fn should_batch(
         .map(|utxo| estimate_input_vsize(&utxo.txout.script_pubkey))
         .sum::<f64>();
 
-    // when batching always use empty OP_RETURN no data, size = 11
-    tx_vsize += 11.0;
+    tx_vsize += match output_script.as_bytes() {
+        // empty OP_RETURN no data, size = 11
+        [0x6a, 0x00] => 11.0,
+        // contains 3 bytes 'ash', size = 14
+        _ => 14.0,
+    };
 
     for tx in unconfirmed_txs {
         let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
@@ -709,7 +731,6 @@ mod test_env;
 mod tests {
     use super::*;
     use corepc_node::AddressType;
-    use test_calc::{InputType, TxSizeCalculator};
     use test_env::TestEnv;
 
     enum OpReturn {
@@ -1013,15 +1034,20 @@ mod tests {
         broadcast_and_assert(&ctx, fully_signed, 1, OpReturn::Empty);
     }
 
-    /// Test batching ddust txs via RBF
-    fn min_sats_for_batching(amt1: Amount, first_tx_vsize: f64, new_input_vsize: f64) -> Amount {
-        let fee_rate = amt1.to_sat() as f64 / first_tx_vsize;
-        let fee_rate_valid_rbf = fee_rate + 0.10;
-        Amount::from_sat((fee_rate_valid_rbf * (first_tx_vsize + new_input_vsize)) as u64) - amt1
-    }
+    /// Test batching ddust txs via RBF:
+    /// 1. Empty OP_RETURN batch (Legacy + Bech32m)
+    /// 2. Ash OP_RETURN batch (Bech32m + Bech32m)
+    /// 3. No batching when fee rate is insufficient for RBF
+    #[test]
+    fn test_spend_batch() {
+        fn min_sats_for_batching(amt1: Amount, first_tx_size: f64, new_input_size: f64) -> Amount {
+            let fee_rate = amt1.to_sat() as f64 / first_tx_size;
+            let fee_rate_valid_rbf = fee_rate + 0.10;
+            Amount::from_sat((fee_rate_valid_rbf * (first_tx_size + new_input_size)) as u64) - amt1
+        }
 
-    fn setup_ctx() -> TestContext {
         let ctx = TestContext::new();
+        let dust_sats = Amount::from_sat(600);
 
         let desc = ctx
             .env
@@ -1039,13 +1065,6 @@ mod tests {
             .env
             .get_descriptor(&ctx.wallet2_name, &AddressType::Bech32m);
         cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        ctx
-    }
-
-    /// 1. Empty OP_RETURN batch (Legacy + Bech32m)
-    #[test]
-    fn test_batch_legacy_bech32() {
-        let ctx = setup_ctx();
 
         // Case: Expect OpReturn::Empty
         let addr1 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Legacy);
@@ -1054,41 +1073,32 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let first_tx_size = TxSizeCalculator::new()
-            .add_input(InputType::P2PKH)
-            .calculate()
-            .vsize;
-        let min_sats = min_sats_for_batching(
-            amt1,
-            first_tx_size,
-            TxSizeCalculator::single_input_vsize(InputType::P2WPKH),
-        );
+        // first tx: overhead + P2PKH input + empty OP_RETURN
+        let first_tx_size = 10.5 + 148.0 + 11.0;
+        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
         ctx.env
             .send_to_address(&addr2, min_sats + Amount::from_sat(10));
         ctx.env.mine_blocks(1);
 
         // first tx
-        let dust_sats = Amount::from_sat(600);
-        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
+        let result = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1);
+        assert!(result.is_some(), "expected a psbt to be created");
+
+        let psbt = result.unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Empty);
 
         // spend addr2 and expect batch of the mempool ddust tx
-        let psbt_batched =
-            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
-        let signed = ctx
-            .env
-            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the original tx output of OpReturn::Empty is preserved
+        let result_batch = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2);
+        assert!(result_batch.is_some(), "expected a psbt to be created");
+
+        let psbt = result_batch.unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet2_name, &psbt);
+        // the orignal tx output of OpReturn::Empty is preserved
         broadcast_and_assert(&ctx, signed.clone(), 2, OpReturn::Empty);
-    }
+        ctx.env.mine_blocks(1);
 
-    /// 2. Empty OP_RETURN batch (Bech32m + Bech32m)
-    #[test]
-    fn test_batch_bech32_bech32() {
-        let ctx = setup_ctx();
-
-        // Case: Replace OpReturn::Ash with OpReturn::Empty
+        // Case: Expect OpReturn::Ash
         let addr1 = ctx
             .env
             .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
@@ -1097,21 +1107,14 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let first_tx_size = TxSizeCalculator::new()
-            .add_input(InputType::P2TR)
-            .calculate()
-            .vsize;
-        let min_sats = min_sats_for_batching(
-            amt1,
-            first_tx_size,
-            TxSizeCalculator::single_input_vsize(InputType::P2TR),
-        );
+        // first tx: overhead + P2TR input + ash OP_RETURN
+        let first_tx_size = 10.5 + 57.5 + 14.0;
+        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
         ctx.env
             .send_to_address(&addr2, min_sats + Amount::from_sat(10));
         ctx.env.mine_blocks(1);
 
         // first tx: spend addr1
-        let dust_sats = Amount::from_sat(600);
         let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
@@ -1122,14 +1125,8 @@ mod tests {
         let signed = ctx
             .env
             .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the original tx output of OpReturn::Ash is replaced by OpReturn::Empty
-        broadcast_and_assert(&ctx, signed, 2, OpReturn::Empty);
-    }
-
-    /// 3. No batching when fee rate is insufficient for RBF
-    #[test]
-    fn test_no_batch_insufficient_rate() {
-        let ctx = setup_ctx();
+        // the orignal tx output of OpReturn::Ash is preserved
+        broadcast_and_assert(&ctx, signed, 2, OpReturn::Ash);
 
         // Case: Expect no batching
         let addr1 = ctx
@@ -1140,27 +1137,20 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let first_tx_size = TxSizeCalculator::new()
-            .add_input(InputType::P2WPKH)
-            .calculate()
-            .vsize;
-        let min_sats = min_sats_for_batching(
-            amt1,
-            first_tx_size,
-            TxSizeCalculator::single_input_vsize(InputType::P2TR),
-        );
+        // first tx: overhead + P2TR input + ash OP_RETURN
+        let first_tx_size = 10.5 + 57.5 + 14.0;
+        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
         // send less than min_sats to prevent a valid RBF
-        dbg!(min_sats);
-        ctx.env.send_to_address(&addr2, min_sats - Amount::ONE_SAT);
+        ctx.env
+            .send_to_address(&addr2, min_sats - Amount::from_sat(10));
         ctx.env.mine_blocks(1);
 
-        let dust_sats = Amount::from_sat(1000);
         let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
 
-        // spend addr2 and expect this tx doesn't replace the original tx because the new fee rate
-        // is not enough to replace the mempool tx
+        // spend addr2 and expect this tx doesnt replace the original tx because new fee rate is
+        // not sufficient to replace the mempool tx
         let psbt_batched =
             cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
         let signed = ctx

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -177,7 +177,7 @@ impl TestEnv {
                 &[
                     json!(psbt.to_string()),
                     json!(true),
-                    json!("NONE|ANYONECANPAY"),
+                    json!("ALL|ANYONECANPAY"),
                 ],
             )
             .unwrap();


### PR DESCRIPTION
In #28 I was too fast to switch to using the input sighash to `NONE|ANYONECANPAY` and didn't fully consider the risk of flooding the mempool and relay network with conflicting RBF transactions. This was described in Murch's [bitcoindev comments](https://groups.google.com/g/bitcoindev/c/pr1z3_j8vTc/m/DqMYltO_AAAJ).  

I think I misunderstood nothingmuch in his [Delving post](https://delvingbitcoin.org/t/disposing-of-dust-attack-utxos/2215/23) and thought he was saying `NONE|ANYONECANPAY` wouldn't cause a problem with conflicting RBF transactions but I think he was exploring what the impact of having a policy carve-out would be that allowed relay of 65b dust disposal transactions so all dust disposal Tx could have an empty `OP_RETURN`.  

This PR reverts parts of #28 and switches the `ddust` code and BIP spec from using `NONE|ANYONECANPAY` back to the original `ALL|ANYONECANPAY` sighash approach.