### PR TITLE
Fix/batch eligibility bip125

### DIFF
--- a/docs/bip-dust-disposal.md
+++ b/docs/bip-dust-disposal.md
@@ -114,8 +114,14 @@ Multiple unconfirmed dust disposal transactions created by unrelated entities ca
 
 1. Pre-signed dust inputs MUST be collected from the public bitcoin network mempool.
 2. Inputs MUST NOT be received directly from other wallet users.
-3. The batch creator MUST add a new dust UTXO input to meet the RBF rules requiring an improved fee amount and rate.
-4. All inputs MUST be spent to the same OP_RETURN output, empty or with the `ash` value.
+3. All inputs MUST be spent to the same OP_RETURN output, empty or with the `ash` value.
+4. The batch creator MUST add a new dust UTXO input and the resulting replacement transaction MUST satisfy BIP 125 RBF rules:
+   - The replacement transaction's absolute fee MUST be at least the sum of the absolute fees of all replaced transactions. In dust disposal transactions this is inherently satisfied because the batcher's new input contributes additional sats that all become fee.
+   - The replacement transaction MUST pay an additional fee of at least the incremental relay fee rate (0.1 sat/vB) multiplied by the replacement transaction's virtual size. Since all input sats become fee in a dust disposal transaction, this reduces to: the sum of the batcher's new dust input values MUST be at least 0.1 sat/vB multiplied by the replacement transaction's virtual size.
+   - The replacement transaction's fee rate MUST exceed the fee rate of every transaction it replaces.
+   - The replacement transaction MUST NOT cause the eviction of more than 100 transactions from the mempool.
+
+5. Unconfirmed dust disposal transactions MUST be sorted in ascending order by fee rate before selecting which to batch. The batch creator MUST iterate through this sorted list and greedily include transactions until an RBF rule is not met. This deterministic ordering ensures all compliant implementations produce the same batch for the same mempool state, preventing implementation fingerprinting.
 
 Batch dust disposal transactions must follow all other transaction construction requirements for non-batched dust disposal transactions.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use bdk_wallet::bitcoin::{
     Address, Amount, EcdsaSighashType, Network, OutPoint, Psbt, ScriptBuf, Sequence,
     TapSighashType, Transaction, TxIn,
 };
+use bdk_wallet::coin_selection::DefaultCoinSelectionAlgorithm;
 use bdk_wallet::descriptor::ExtendedDescriptor;
 
 use bdk_bitcoind_rpc::Emitter;
@@ -172,64 +173,23 @@ fn cmd_spend(
                     .add_utxos(&utxos)
                     .expect("failed to add dust outpoints");
 
-                if !unconfirmed_txs.is_empty()
-                    && should_batch(
-                        rpc_client,
-                        input_amount,
-                        &unconfirmed_txs,
-                        &dust,
-                        &unconfirmed_txs[0].output[0].script_pubkey,
-                    )
-                {
-                    debug!("unconfirmed txs can be batched");
-                    for tx in &unconfirmed_txs {
-                        for input in &tx.input {
-                            let f_outpoint = input.previous_output;
-                            let f_input_prev_tx = rpc_client
-                                .get_raw_transaction(&f_outpoint.txid, None)
-                                .unwrap();
-                            let f_prev_txout =
-                                f_input_prev_tx.output[f_outpoint.vout as usize].clone();
-
-                            input_amount += f_prev_txout.value;
-
-                            let mut f_psbt_input = Input::default();
-                            // p2tr sighash algorithm commits to all input amounts, thus
-                            // non_witness_utxo is not needed to verify the input value
-                            if f_prev_txout.script_pubkey.is_p2tr() {
-                                f_psbt_input.witness_utxo = Some(f_prev_txout);
-                            } else {
-                                f_psbt_input.non_witness_utxo = Some(f_input_prev_tx.clone());
-                            }
-                            if !input.witness.is_empty() {
-                                f_psbt_input.final_script_witness = Some(input.witness.clone());
-                            }
-                            if !input.script_sig.is_empty() {
-                                f_psbt_input.final_script_sig = Some(input.script_sig.clone());
-                            }
-                            tx_builder
-                                .add_foreign_utxo_with_sequence(
-                                    f_outpoint,
-                                    f_psbt_input,
-                                    input.segwit_weight(),
-                                    input.sequence,
-                                )
-                                .unwrap_or_else(|_| {
-                                    panic!(
-                                        "failed to add the foreign UTXO. Outpoint: {}",
-                                        f_outpoint
-                                    )
-                                });
-                        }
-                    }
+                let batchable_txs = find_batchable_txs(rpc_client, &dust, &unconfirmed_txs);
+                if !batchable_txs.is_empty() {
+                    debug!(
+                        "batching {} of {} unconfirmed txs",
+                        batchable_txs.len(),
+                        unconfirmed_txs.len()
+                    );
+                    num_inputs += batchable_txs.len();
+                    input_amount += add_foreign_utxos(rpc_client, &mut tx_builder, &batchable_txs);
                 }
 
                 info!("total spent to fees: {}", &input_amount);
                 tx_builder.fee_absolute(input_amount);
 
-                if !unconfirmed_txs.is_empty() {
+                if !batchable_txs.is_empty() {
                     // the new tx shall use the data found in the unconfirmed txs
-                    let suggested_script = &unconfirmed_txs[0].output[0].script_pubkey;
+                    let suggested_script = &batchable_txs[0].output[0].script_pubkey;
                     let op_return = match suggested_script.as_bytes() {
                         // empty OP_RETURN no data
                         [0x6a, 0x00] => vec![],
@@ -565,6 +525,53 @@ fn find_unconfirmed_ddust_txs(rpc_client: &Client) -> Vec<Transaction> {
     unconfirmed_txs
 }
 
+/// Adds pre-signed inputs from unconfirmed ddust transactions as foreign UTXOs
+/// to the given tx_builder. Returns the total amount added.
+fn add_foreign_utxos(
+    rpc_client: &Client,
+    tx_builder: &mut bdk_wallet::TxBuilder<'_, DefaultCoinSelectionAlgorithm>,
+    unconfirmed_txs: &[Transaction],
+) -> Amount {
+    let mut added_amount = Amount::ZERO;
+    for tx in unconfirmed_txs {
+        for input in &tx.input {
+            let f_outpoint = input.previous_output;
+            let f_input_prev_tx = rpc_client
+                .get_raw_transaction(&f_outpoint.txid, None)
+                .unwrap();
+            let f_prev_txout = f_input_prev_tx.output[f_outpoint.vout as usize].clone();
+
+            added_amount += f_prev_txout.value;
+
+            let mut f_psbt_input = Input::default();
+            // p2tr sighash algorithm commits to all input amounts, thus
+            // non_witness_utxo is not needed to verify the input value
+            if f_prev_txout.script_pubkey.is_p2tr() {
+                f_psbt_input.witness_utxo = Some(f_prev_txout);
+            } else {
+                f_psbt_input.non_witness_utxo = Some(f_input_prev_tx.clone());
+            }
+            if !input.witness.is_empty() {
+                f_psbt_input.final_script_witness = Some(input.witness.clone());
+            }
+            if !input.script_sig.is_empty() {
+                f_psbt_input.final_script_sig = Some(input.script_sig.clone());
+            }
+            tx_builder
+                .add_foreign_utxo_with_sequence(
+                    f_outpoint,
+                    f_psbt_input,
+                    input.segwit_weight(),
+                    input.sequence,
+                )
+                .unwrap_or_else(|_| {
+                    panic!("failed to add the foreign UTXO. Outpoint: {}", f_outpoint)
+                });
+        }
+    }
+    added_amount
+}
+
 /// ddust pattern:
 /// has a single op_return
 /// one or more inputs with ALL|ANYONECANPAY signature type
@@ -661,27 +668,28 @@ fn is_dust(out: &LocalOutput, dust_amount: &Amount) -> bool {
     !out.is_spent && out.txout.value <= *dust_amount && out.chain_position.is_confirmed()
 }
 
-/// Checks if batching dust inputs with existing ddust transactions in the mempool
-/// produces a fee rate at least 0.01 sat/vB higher than the highest existing fee rate,
-/// as required by RBF replacement rules.
-fn should_batch(
+/// Finds the subset of unconfirmed ddust transactions that can be batched together. Sorts by fee
+/// rate ascending and accumulates transactions, stopping when adding the next one would drop the
+/// combined fee rate below the RBF threshold. `dust_utxos` represent the inputs that the batcher
+/// wants to add
+///
+/// Sorting by fee rate ascending allows adding cheap ones first to increase likelyhood of batching
+fn find_batchable_txs(
     rpc_client: &Client,
-    this_amount: Amount,
-    unconfirmed_txs: &Vec<Transaction>,
     dust_utxos: &[LocalOutput],
-    output_script: &ScriptBuf,
-) -> bool {
-    // this tx fee rate > max foreign tx fee rate
-    // this tx fee rate = fee / vsize
-    // -> total dust amt / vsize
-    // vsize = overhead + one op_return output + (new dust utxos + foreign utxos)
-    let mut max_fee_rate: f64 = 0.0;
-    let mut tx_vsize: f64 = 0.0;
-    let mut input_amount: Amount = this_amount;
+    unconfirmed_txs: &[Transaction],
+) -> Vec<Transaction> {
+    if unconfirmed_txs.is_empty() || dust_utxos.is_empty() {
+        return vec![];
+    }
+    let output_script = &unconfirmed_txs[0].output[0].script_pubkey;
 
-    // overhead size
-    tx_vsize += 10.5;
-    // size of dust inputs to be spent
+    let mut batchable: Vec<Transaction> = vec![];
+    let tx_input_amount: Amount = dust_utxos.iter().map(|out| out.txout.value).sum();
+
+    // replacement tx vsize
+    // overhead
+    let mut tx_vsize = 10.5;
     tx_vsize += dust_utxos
         .iter()
         .map(|utxo| estimate_input_vsize(&utxo.txout.script_pubkey))
@@ -694,31 +702,51 @@ fn should_batch(
         _ => 14.0,
     };
 
-    for tx in unconfirmed_txs {
-        let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
-        let fee = entry.fees.base;
-        input_amount += fee;
-        let fee_sats = fee.to_sat();
-        let vsize = entry.vsize;
-        let rate = fee_sats as f64 / vsize as f64;
-        if rate > max_fee_rate {
-            max_fee_rate = rate;
-        }
+    // collect fee rate info for each unconfirmed tx
+    let mut tx_info: Vec<(Transaction, Amount, f64, f64)> = unconfirmed_txs
+        .iter()
+        .map(|tx| {
+            let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
+            let fee = entry.fees.base;
+            let vsize = entry.vsize as f64;
+            let rate = fee.to_sat() as f64 / vsize;
+            let input_vsize: f64 = tx.input.iter().map(|i| get_input_vsize(i)).sum();
+            info!("vsize: {} and input size: {}", vsize, input_vsize);
+            (tx.clone(), fee, rate, input_vsize)
+        })
+        .collect();
 
-        for input in &tx.input {
-            // foreign utxo input size
-            tx_vsize += get_input_vsize(input);
+    // sort by fee rate ascending to add cheap ones first. because of this ordering, the current
+    // iteration's `rate` is always the max rate among txs accepted so far, so comparing
+    // `new_fee_rate > rate + 0.1` is equivalent to "new rate > max replaced rate + 0.1".
+    tx_info.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+
+    let mut combined_vsize: f64 = tx_vsize;
+    let mut combined_amount: Amount = tx_input_amount;
+
+    for (tx, fee, rate, input_vsize) in tx_info {
+        let new_amount = combined_amount + fee;
+        let new_vsize = combined_vsize + input_vsize;
+        let new_fee_rate = new_amount.to_sat() as f64 / new_vsize;
+        if new_fee_rate > rate + 0.1 {
+            debug!(
+                "batchable: adding tx with rate {:.3} sat/vB, combined rate {:.3} sat/vB",
+                rate, new_fee_rate
+            );
+            combined_amount = new_amount;
+            combined_vsize = new_vsize;
+            batchable.push(tx);
+        } else {
+            // sorted ascending, so any subsequent tx has rate >= this one and would also fail.
+            debug!(
+                "batchable: stopping at tx with rate {:.3} sat/vB (combined rate {:.3} would not exceed threshold)",
+                rate, new_fee_rate
+            );
+            break;
         }
     }
 
-    let tx_fee_rate = input_amount.to_sat() as f64 / tx_vsize;
-    debug!(
-        "tx_fee_rate: {}, max_fee_rate: {}, batch? {}",
-        tx_fee_rate,
-        max_fee_rate,
-        tx_fee_rate > max_fee_rate + 0.1
-    );
-    tx_fee_rate > max_fee_rate + 0.1
+    batchable
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -668,12 +668,18 @@ fn is_dust(out: &LocalOutput, dust_amount: &Amount) -> bool {
     !out.is_spent && out.txout.value <= *dust_amount && out.chain_position.is_confirmed()
 }
 
-/// Finds the subset of unconfirmed ddust transactions that can be batched together. Sorts by fee
-/// rate ascending and accumulates transactions, stopping when adding the next one would drop the
-/// combined fee rate below the RBF threshold. `dust_utxos` represent the inputs that the batcher
-/// wants to add
+/// Selects unconfirmed ddust transactions that can be batched into a single RBF-compliant replacement.
+/// `dust_utxos` are extra inputs added by the batcher.
 ///
-/// Sorting by fee rate ascending allows adding cheap ones first to increase likelyhood of batching
+/// Replacement fee:
+/// new_fee = sum(dust_utxos) + sum(replaced_fees)
+///
+/// A transaction is included only if:
+///
+/// * Total fee pays at least the absolute fee of all replaced txs. This is gauranteed since each tx contributes > 0 sats
+/// * Replacement tx pays for its own bandwidth i.e. Added fee > 0.1 × replacement_vsize
+/// * Replacement feerate exceeds all included txs (processed in ascending order)
+/// * Total replaced txs stay within the mempool eviction limit (100)
 fn find_batchable_txs(
     rpc_client: &Client,
     dust_utxos: &[LocalOutput],
@@ -685,7 +691,6 @@ fn find_batchable_txs(
     let output_script = &unconfirmed_txs[0].output[0].script_pubkey;
 
     let mut batchable: Vec<Transaction> = vec![];
-    let tx_input_amount: Amount = dust_utxos.iter().map(|out| out.txout.value).sum();
 
     // replacement tx vsize
     // overhead
@@ -702,7 +707,10 @@ fn find_batchable_txs(
         _ => 14.0,
     };
 
-    // collect fee rate info for each unconfirmed tx
+    let tx_input_amount: Amount = dust_utxos.iter().map(|out| out.txout.value).sum();
+    let dust_amount_sats = tx_input_amount.to_sat() as f64;
+
+    // collect fee, rate and input vsize for each unconfirmed tx
     let mut tx_info: Vec<(Transaction, Amount, f64, f64)> = unconfirmed_txs
         .iter()
         .map(|tx| {
@@ -710,37 +718,49 @@ fn find_batchable_txs(
             let fee = entry.fees.base;
             let vsize = entry.vsize as f64;
             let rate = fee.to_sat() as f64 / vsize;
-            let input_vsize: f64 = tx.input.iter().map(|i| get_input_vsize(i)).sum();
-            info!("vsize: {} and input size: {}", vsize, input_vsize);
+            let input_vsize: f64 = tx.input.iter().map(get_input_vsize).sum();
             (tx.clone(), fee, rate, input_vsize)
         })
         .collect();
 
-    // sort by fee rate ascending to add cheap ones first. because of this ordering, the current
-    // iteration's `rate` is always the max rate among txs accepted so far, so comparing
-    // `new_fee_rate > rate + 0.1` is equivalent to "new rate > max replaced rate + 0.1".
+    // sort ascending by fee rate so the rate check against the current iteration's rate
+    // covers all previously accepted txs (their rates are <= current).
     tx_info.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+
+    // mempool eviction cap
+    const MAX_REPLACED: usize = 100;
 
     let mut combined_vsize: f64 = tx_vsize;
     let mut combined_amount: Amount = tx_input_amount;
 
     for (tx, fee, rate, input_vsize) in tx_info {
+        if batchable.len() >= MAX_REPLACED {
+            debug!("batchable: hit eviction cap of {} txs", MAX_REPLACED);
+            break;
+        }
         let new_amount = combined_amount + fee;
         let new_vsize = combined_vsize + input_vsize;
-        let new_fee_rate = new_amount.to_sat() as f64 / new_vsize;
-        if new_fee_rate > rate + 0.1 {
+        let new_rate = new_amount.to_sat() as f64 / new_vsize;
+
+        // additional fee (dust_amount_sats) must cover incremental relay over new vsize.
+        let bandwidth_ok = dust_amount_sats >= 0.1 * new_vsize;
+        // replacement rate must exceed every replaced tx's rate.
+        let rate_ok = new_rate > rate;
+
+        if bandwidth_ok && rate_ok {
             debug!(
-                "batchable: adding tx with rate {:.3} sat/vB, combined rate {:.3} sat/vB",
-                rate, new_fee_rate
+                "batchable: adding tx (rate {:.3}, combined rate {:.3}, combined vsize {:.1})",
+                rate, new_rate, new_vsize
             );
             combined_amount = new_amount;
             combined_vsize = new_vsize;
             batchable.push(tx);
         } else {
-            // sorted ascending, so any subsequent tx has rate >= this one and would also fail.
+            // sorted ascending by rate, so subsequent txs have rate >= this one (rate check
+            // gets harder) and add at least some vsize (bandwidth check gets harder).
             debug!(
-                "batchable: stopping at tx with rate {:.3} sat/vB (combined rate {:.3} would not exceed threshold)",
-                rate, new_fee_rate
+                "batchable: stopping at rate {:.3} (bandwidth_ok={}, rate_ok={}, combined rate {:.3}, combined vsize {:.1})",
+                rate, bandwidth_ok, rate_ok, new_rate, new_vsize
             );
             break;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,6 @@ fn cmd_spend(
                         batchable_txs.len(),
                         unconfirmed_txs.len()
                     );
-                    num_inputs += batchable_txs.len();
                     input_amount += add_foreign_utxos(rpc_client, &mut tx_builder, &batchable_txs);
                 }
 
@@ -518,6 +517,7 @@ fn find_unconfirmed_ddust_txs(rpc_client: &Client) -> Vec<Transaction> {
                 let script_bytes = tx.output[0].script_pubkey.as_bytes().to_vec();
                 first_found_script = Some(script_bytes);
             }
+
             unconfirmed_txs.push(tx);
         }
     }
@@ -777,6 +777,8 @@ mod test_env;
 
 #[cfg(test)]
 mod tests {
+    use crate::test_calc::{InputType, TxSizeCalculator};
+
     use super::*;
     use corepc_node::AddressType;
     use test_env::TestEnv;
@@ -1056,9 +1058,11 @@ mod tests {
     fn test_spend_multisig() {
         let ctx = TestContext::new();
 
-        let (addr, desc) = ctx
-            .env
-            .create_multisig(&[&ctx.wallet1_name, &ctx.wallet2_name], 2);
+        let (addr, desc) = ctx.env.create_multisig(
+            &[&ctx.wallet1_name, &ctx.wallet2_name],
+            2,
+            &AddressType::Legacy,
+        );
 
         cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
         ctx.env.send_to_address(&addr, Amount::from_sat(555));
@@ -1082,24 +1086,39 @@ mod tests {
         broadcast_and_assert(&ctx, fully_signed, 1, OpReturn::Empty);
     }
 
-    /// Test batching ddust txs via RBF:
-    /// 1. Empty OP_RETURN batch (Legacy + Bech32m)
-    /// 2. Ash OP_RETURN batch (Bech32m + Bech32m)
-    /// 3. No batching when fee rate is insufficient for RBF
-    #[test]
-    fn test_spend_batch() {
-        fn min_sats_for_batching(amt1: Amount, first_tx_size: f64, new_input_size: f64) -> Amount {
-            let fee_rate = amt1.to_sat() as f64 / first_tx_size;
-            let fee_rate_valid_rbf = fee_rate + 0.10;
-            Amount::from_sat((fee_rate_valid_rbf * (first_tx_size + new_input_size)) as u64) - amt1
+    /// Minimum sats the batcher's dust must be worth for the replacement to satisfy RBF.
+    /// The replacement must:
+    ///  - have a higher fee rate than the replaced tx
+    ///  - pay for its own bandwidth (incremental relay fee: 0.1 sat/vB * replacement vsize)
+    fn min_sats_for_batching(
+        orig_tx_fee: Amount,
+        orig_tx_input_types: &[InputType],
+        replacement_tx_input_type: InputType,
+    ) -> Amount {
+        let mut orig_tx = TxSizeCalculator::new();
+        for input_type in orig_tx_input_types {
+            orig_tx = orig_tx.add_input(*input_type);
         }
-
+        let orig_tx_vsize = orig_tx.calculate().vsize.ceil();
+        let replacement_tx = orig_tx.add_input(replacement_tx_input_type);
+        let replacement_tx_vsize = replacement_tx.calculate().vsize.ceil();
+        let fee_rate = orig_tx_fee.to_sat() as f64 / orig_tx_vsize;
+        // requires atleast `sats` at the fee rate of the original tx
+        let rate_min_sats = (fee_rate * replacement_tx_vsize) as u64 - orig_tx_fee.to_sat();
+        // requires `sats` that pay the replacement_vsize at the relay rate
+        let bandwidth_min_sats = (0.1 * replacement_tx_vsize) as u64;
+        Amount::from_sat(bandwidth_min_sats.max(rate_min_sats))
+    }
+    fn setup_ctx() -> TestContext {
         let ctx = TestContext::new();
-        let dust_sats = Amount::from_sat(600);
 
         let desc = ctx
             .env
             .get_descriptor(&ctx.wallet1_name, &AddressType::Legacy);
+        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
+        let desc = ctx
+            .env
+            .get_descriptor(&ctx.wallet1_name, &AddressType::Bech32);
         cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
         let desc = ctx
             .env
@@ -1113,6 +1132,18 @@ mod tests {
             .env
             .get_descriptor(&ctx.wallet2_name, &AddressType::Bech32m);
         cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
+        let desc = ctx
+            .env
+            .get_descriptor(&ctx.wallet2_name, &AddressType::Bech32);
+        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
+
+        ctx
+    }
+
+    /// 1. Empty OP_RETURN batch (Legacy + Bech32m)
+    #[test]
+    fn test_batch_legacy_bech32() {
+        let ctx = setup_ctx();
 
         // Case: Expect OpReturn::Empty
         let addr1 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Legacy);
@@ -1121,32 +1152,33 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        // first tx: overhead + P2PKH input + empty OP_RETURN
-        let first_tx_size = 10.5 + 148.0 + 11.0;
-        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
-        ctx.env
-            .send_to_address(&addr2, min_sats + Amount::from_sat(10));
+        let min_sats = min_sats_for_batching(amt1, &[InputType::P2PKH], InputType::P2WPKH);
+        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
         ctx.env.mine_blocks(1);
 
         // first tx
-        let result = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1);
-        assert!(result.is_some(), "expected a psbt to be created");
-
-        let psbt = result.unwrap();
+        let dust_sats = Amount::from_sat(600);
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Empty);
 
         // spend addr2 and expect batch of the mempool ddust tx
-        let result_batch = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2);
-        assert!(result_batch.is_some(), "expected a psbt to be created");
-
-        let psbt = result_batch.unwrap();
-        let signed = ctx.env.wallet_process_psbt(&ctx.wallet2_name, &psbt);
-        // the orignal tx output of OpReturn::Empty is preserved
+        let psbt_batched =
+            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
+        let signed = ctx
+            .env
+            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
+        // the original tx output of OpReturn::Empty is preserved
         broadcast_and_assert(&ctx, signed.clone(), 2, OpReturn::Empty);
-        ctx.env.mine_blocks(1);
+    }
 
-        // Case: Expect OpReturn::Ash
+    /// 2. OpReturn:Ash OP_RETURN batch (Bech32m + Bech32m)
+    #[test]
+    fn test_batch_bech32_bech32() {
+        let ctx = setup_ctx();
+
+        // Case: The first Bech32m spend outputs an OpReturn:Ash, the second Bech32m spend
+        // keeps op_return:Ash from the replaced tx
         let addr1 = ctx
             .env
             .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
@@ -1155,14 +1187,12 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        // first tx: overhead + P2TR input + ash OP_RETURN
-        let first_tx_size = 10.5 + 57.5 + 14.0;
-        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
-        ctx.env
-            .send_to_address(&addr2, min_sats + Amount::from_sat(10));
+        let min_sats = min_sats_for_batching(amt1, &[InputType::P2TR], InputType::P2TR);
+        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
         ctx.env.mine_blocks(1);
 
         // first tx: spend addr1
+        let dust_sats = Amount::from_sat(600);
         let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
@@ -1173,8 +1203,14 @@ mod tests {
         let signed = ctx
             .env
             .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the orignal tx output of OpReturn::Ash is preserved
+        // the original tx output of OpReturn::Ash is preserved
         broadcast_and_assert(&ctx, signed, 2, OpReturn::Ash);
+    }
+
+    /// 3. No batching when fee rate is insufficient for RBF
+    #[test]
+    fn test_no_batch_insufficient_rate() {
+        let ctx = setup_ctx();
 
         // Case: Expect no batching
         let addr1 = ctx
@@ -1185,25 +1221,196 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        // first tx: overhead + P2TR input + ash OP_RETURN
-        let first_tx_size = 10.5 + 57.5 + 14.0;
-        let min_sats = min_sats_for_batching(amt1, first_tx_size, 57.5);
+        let min_sats = min_sats_for_batching(amt1, &[InputType::P2WPKH], InputType::P2TR);
         // send less than min_sats to prevent a valid RBF
-        ctx.env
-            .send_to_address(&addr2, min_sats - Amount::from_sat(10));
+        dbg!(min_sats);
+        ctx.env.send_to_address(&addr2, min_sats - Amount::ONE_SAT);
         ctx.env.mine_blocks(1);
 
+        let dust_sats = Amount::from_sat(1000);
         let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
         let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
 
-        // spend addr2 and expect this tx doesnt replace the original tx because new fee rate is
-        // not sufficient to replace the mempool tx
+        // spend addr2 and expect this tx doesn't replace the original tx because the new fee rate
+        // is not enough to replace the mempool tx
         let psbt_batched =
             cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
         let signed = ctx
             .env
             .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
         broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
+    }
+
+    /// 4. picks batchable unconfirmed ddust txs
+    ///
+    /// Setup: steps 1 creates the first ddust tx, step 2 creates another and batches the previous tx
+    /// Steps 3 and 4 sends just under `min_sats_for_batching` (against the
+    /// lowest-rate existing tx), so each step is forced to stand alone. Step 5 sends a
+    /// large enough P2TR dust and batches one unconfirmed tx, leaving other txs unbatched
+    ///
+    /// Input types (each at its own address): P2TR, P2TR, P2PKH, P2WPKH, P2TR (batcher).
+    #[test]
+    fn test_batch_pick_batchable() {
+        let ctx = setup_ctx();
+
+        // addresses
+        let addr1 = ctx
+            .env
+            .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
+        let addr2 = ctx
+            .env
+            .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
+        let addr3 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Legacy);
+        let addr4 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Bech32);
+        let addr5 = ctx
+            .env
+            .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
+
+        // step 1: any valid starting dust (no mempool ddust yet).
+        let amt1 = Amount::from_sat(300);
+        ctx.env.send_to_address(&addr1, amt1);
+
+        // step 2 (new P2TR input): > min_sats_for_batching(tx1) batches the previous p2tr input.
+        let min_sats_p2tr_p2tr = min_sats_for_batching(amt1, &[InputType::P2TR], InputType::P2TR);
+        let amt_batch_p2tr_p2tr = min_sats_p2tr_p2tr + Amount::ONE_SAT;
+        ctx.env.send_to_address(&addr2, amt_batch_p2tr_p2tr);
+
+        // step 3 (new P2PKH input): doesn't batch
+        let min_sats_batchedp2tr_p2pkh = min_sats_for_batching(
+            amt1 + amt_batch_p2tr_p2tr,
+            &[InputType::P2TR, InputType::P2TR],
+            InputType::P2PKH,
+        );
+        let amt_no_batch_2p2tr_p2pkh = min_sats_batchedp2tr_p2pkh - Amount::ONE_SAT;
+        ctx.env.send_to_address(&addr3, amt_no_batch_2p2tr_p2pkh);
+
+        // step 4 (new P2WPKH input): doesn't batch
+        let min_sats_p2wpkh = min_sats_for_batching(
+            amt_no_batch_2p2tr_p2pkh,
+            &[InputType::P2PKH],
+            InputType::P2WPKH,
+        );
+        let amt_p2wpkh_no_batch = min_sats_p2wpkh - Amount::ONE_SAT;
+        ctx.env.send_to_address(&addr4, amt_p2wpkh_no_batch);
+
+        // step 5 (new P2TR input): just enough to batch the P2WPKH input
+        let amt_p2tr_batch = amt_p2wpkh_no_batch + Amount::ONE_SAT;
+        ctx.env.send_to_address(&addr5, amt_p2tr_batch);
+
+        ctx.env.mine_blocks(1);
+
+        let dust_sats = Amount::from_sat(2500);
+
+        // 1. spend addr1 - standalone (no mempool ddust yet)
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
+
+        // 2. spend addr2 - batches input from previous tx
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet2_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 2, OpReturn::Ash);
+
+        // 3. spend addr3 - standalone (P2PKH amount below the lowest batch threshold)
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr3).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 1, OpReturn::Empty);
+
+        // 4. spend addr4 - standalone (P2WPKH amount below the lowest batch threshold)
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr4).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
+
+        // 5. spend addr5 - batches 1 unconfirmed tx into a single 2-input replacement.
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr5).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet2_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 2, OpReturn::Ash);
+    }
+
+    /// 5. test BIP 125 mempool eviction limit that limits how many unconfirmed txs you can
+    ///    replace. The limit currently set to 100
+    #[test]
+    fn test_batch_mempool_eviction_limit() {
+        let ctx = setup_ctx();
+
+        let mut addressses = vec![];
+        // create > 100 dust UTXOs
+        for i in 0..120 {
+            let addr = ctx
+                .env
+                .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
+            ctx.env.send_to_address(&addr, Amount::from_sat(300));
+            addressses.push(addr);
+            // mine periodically to prevent chain of transactions
+            if i % 20 == 0 {
+                ctx.env.mine_blocks(1);
+            }
+        }
+        // a large UTXO will be used to batch all the unconfirmed ddust txs(upto 100)
+        let addr_batcher1 = ctx
+            .env
+            .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
+        ctx.env
+            .send_to_address(&addr_batcher1, Amount::from_sat(1000));
+        // another large UTXO will be used to batch all remaining 20 unconfirmed ddust txs
+        let addr_batcher2 = ctx
+            .env
+            .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
+        ctx.env
+            .send_to_address(&addr_batcher2, Amount::from_sat(1000));
+
+        ctx.env.mine_blocks(1);
+
+        let dust_sats = Amount::from_sat(1000);
+
+        // spend each dust UTXO as a standalone ddust tx, mining a block after each
+        // to confirm it (preventing batching)
+        for addr in addressses {
+            let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr).unwrap();
+            let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+            broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
+            ctx.env.mine_blocks(1);
+        }
+
+        // invalidate blocks to put all 120 ddust txs back into the mempool
+        let count: serde_json::Value = ctx.env.node.client.call("getblockcount", &[]).unwrap();
+        let target_height = count.as_u64().unwrap() - 120;
+        // repeatedly invalidate the current tip until target_height is reached
+        loop {
+            let tip = ctx.env.node.client.call("getbestblockhash", &[]).unwrap();
+            let height: u64 = ctx.env.node.client.call("getblockcount", &[]).unwrap();
+
+            if height <= target_height {
+                break;
+            }
+
+            ctx.env.node.client.invalidate_block(tip).unwrap();
+        }
+
+        // final ddust tx1: batches up to 100 mempool txs
+        let psbt = cmd_spend(
+            &ctx.db,
+            ctx.network,
+            &ctx.rpc_client,
+            dust_sats,
+            addr_batcher1,
+        )
+        .unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        // 101 = one self + 100 from mempool
+        broadcast_and_assert(&ctx, signed, 101, OpReturn::Ash);
+
+        // final ddust tx2: batches remaining 20 mempool txs plus ddust tx1
+        let psbt = cmd_spend(
+            &ctx.db,
+            ctx.network,
+            &ctx.rpc_client,
+            dust_sats,
+            addr_batcher2,
+        )
+        .unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        broadcast_and_assert(&ctx, signed, 122, OpReturn::Ash);
     }
 }

--- a/src/test_calc.rs
+++ b/src/test_calc.rs
@@ -145,9 +145,9 @@ impl TxSizeCalculator {
 
         // Check if we need "ash" padding to meet minimum size
         // Only single witness inputs need padding
-        let base_with_empty = Self::OVERHEAD + input_base + Self::OP_RETURN_EMPTY;
-        let needs_ash =
-            self.inputs.len() == 1 && has_witness && base_with_empty < Self::MIN_BASE_SIZE;
+        let first_input_base_with_empty =
+            Self::OVERHEAD + Self::input_base_size(&self.inputs[0]) + Self::OP_RETURN_EMPTY;
+        let needs_ash = first_input_base_with_empty < Self::MIN_BASE_SIZE;
 
         let output_bytes = if needs_ash {
             Self::OP_RETURN_ASH
@@ -493,14 +493,14 @@ mod tests {
     // ==================== Multiple Input Tests ====================
 
     #[test]
-    fn test_multiple_p2tr_inputs_uses_empty() {
+    fn test_multiple_p2tr_inputs_preserves_ash() {
         let size = TxSizeCalculator::new()
             .add_input(InputType::P2TR)
             .add_input(InputType::P2TR)
             .calculate();
 
         // Multiple inputs always use empty OP_RETURN
-        assert_eq!(size.output_bytes, 11);
+        assert_eq!(size.output_bytes, 14);
         assert_eq!(size.input_base_bytes, 82); // 41 * 2
         assert_eq!(size.input_witness_bytes, 134); // 67 * 2
     }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -131,12 +131,21 @@ impl TestEnv {
     }
 
     /// Create a `required`-of-N multisig address from the given wallets.
+    /// `address_type` controls the output script: Legacy -> P2SH, P2shSegwit -> P2SH-P2WSH,
+    /// Bech32 -> P2WSH. Bech32m (taproot) is not supported by createmultisig.
     /// Returns the multisig address and its descriptor.
     pub fn create_multisig(
         &self,
         wallet_names: &[&str],
         required: usize,
+        address_type: &AddressType,
     ) -> (Address, ExtendedDescriptor) {
+        let address_type_str = match address_type {
+            AddressType::Legacy => "legacy",
+            AddressType::P2shSegwit => "p2sh-segwit",
+            AddressType::Bech32 => "bech32",
+            AddressType::Bech32m => panic!("taproot multisig is not supported by createmultisig"),
+        };
         let pubkeys: Vec<PublicKey> = wallet_names
             .iter()
             .map(|name| {
@@ -151,21 +160,30 @@ impl TestEnv {
             })
             .collect();
 
-        let result = self
+        // call createmultisig directly so we can pass an explicit address_type.
+        let pubkey_hexes: Vec<String> = pubkeys.iter().map(|pk| pk.to_string()).collect();
+        let result: serde_json::Value = self
             .node
             .client
-            .create_multisig(required as u32, pubkeys)
+            .call(
+                "createmultisig",
+                &[
+                    json!(required),
+                    json!(pubkey_hexes),
+                    json!(address_type_str),
+                ],
+            )
             .unwrap();
 
+        let address = result["address"].as_str().unwrap();
+        let descriptor = result["descriptor"].as_str().unwrap();
+
         let secp = Secp256k1::new();
-        let desc = ExtendedDescriptor::parse_descriptor(&secp, &result.descriptor)
+        let desc = ExtendedDescriptor::parse_descriptor(&secp, descriptor)
             .map(|(d, _)| d)
             .unwrap();
 
-        (
-            Address::from_str(&result.address).unwrap().assume_checked(),
-            desc,
-        )
+        (Address::from_str(address).unwrap().assume_checked(), desc)
     }
 
     /// Process and sign a PSBT using the given wallet.


### PR DESCRIPTION
fixes #30 

---
  - Refactored `should_batch` -> `find_batchable_txs`: instead of returning a `bool`, returns the subset of unconfirmed ddust txs that can be batched. This lets us batch as many txs as possible instead of all-or-nothing.
  - `batching` of ddust txs now follow RBF rules as stated in [BIP 125](https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki) through fn  `find_batchable_txs`: sorts mempool txs ascending by fee rate, greedily includes each if the replacement fee rate exceeds the replaced tx's rate and the bandwidth cost is covered, stops at the first failure or at 100 evictions.
  - Added test for batching(pick as many batchable ddust txs as possible) and mempool eviction. Refactored test fn `min_sats_for_batching` to correctly account for both: the rate and bandwidth RBF constraints. Updated batch tests to use it for deriving dust amounts.
  - Updated `create_multisig` in test_env to accept an address_type parameter.
  - Updated BIP spec batching section: stated RBF rules a replacement must satisfy and added a deterministic sort order (ascending fee rate, greedy) so different implementations don't fingerprint themselves.
