### PR TITLE
Assume low-R grinded ECDSA signatures. Add more batching test scenarios, multi input orig tx batching

### DIFF
--- a/docs/bip-dust-disposal.md
+++ b/docs/bip-dust-disposal.md
@@ -240,23 +240,25 @@ All valid dust disposal transactions should be verified to be accepted into the 
 
 |                   | P2PKH | P2SH (2-3) | P2WPKH | P2WSH (2-3) | P2TR  |
 |-------------------|-------|------------|--------|-------------|-------|
-| Overhead (b)      | 10    | 10         | 10     | 10          | 10    | 
-| Input (b)         | 148   | 295        | 41     | 41          | 41    |
+| Overhead (b)      | 10    | 10         | 10     | 10          | 10    |
+| Input (b)         | 147   | 293        | 41     | 41          | 41    |
 | OP_RETURN (b)     | 11    | 11         | 14     | 14          | 14    |
-| Base size (b)     | 169   | 316        | 65     | 65          | 65    |
-| Witness data (b)  | 0     | 0          | 108    | 255         | 67    |
-| Size (b)          | 169   | 316        | 173    | 320         | 132   |
-| Weight (wu)       | 676   | 1264       | 370    | 517         | 329   |
-| Virtual Size (vb) | 169   | 316        | 92.5   | 129.25      | 82.25 | 
+| Base size (b)     | 168   | 314        | 65     | 65          | 65    |
+| Witness data (b)  | 0     | 0          | 107    | 252         | 67    |
+| Size (b)          | 168   | 314        | 172    | 317         | 132   |
+| Weight (wu)       | 672   | 1256       | 369    | 514         | 329   |
+| Virtual Size (vb) | 168   | 314        | 92.25  | 128.5       | 82.25 |
+
+ECDSA-signed inputs assume low-R signature grinding (71-byte signatures including the sighash byte)
 
 #### Example dust disposal transaction fee rates (sats/vb)
 
 | Input Amount | P2PKH   | P2SH (2-3) | P2WPKH | P2WSH (2-3) | P2TR  |
 |--------------|---------|------------|--------|-------------|-------|
-| 294          | 1.74    | 0.93       | 3.18   | 2.27        | 3.57  |
-| 300          | 1.78    | 0.95       | 3.24   | 2.32        | 3.65  |
-| 325          | 1.92    | 1.03       | 3.51   | 2.51        | 3.95  |
-| 330          | 1.95    | 1.04       | 3.57   | 2.55        | 4.01  |
+| 294          | 1.75    | 0.94       | 3.19   | 2.29        | 3.57  |
+| 300          | 1.79    | 0.96       | 3.25   | 2.33        | 3.65  |
+| 325          | 1.93    | 1.04       | 3.52   | 2.53        | 3.95  |
+| 330          | 1.96    | 1.05       | 3.58   | 2.57        | 4.01  |
 
 ### Batching dust disposal txs via RBF
 

--- a/docs/bip-dust-disposal.md
+++ b/docs/bip-dust-disposal.md
@@ -240,18 +240,18 @@ All valid dust disposal transactions should be verified to be accepted into the 
 
 |                   | P2PKH | P2SH (2-3) | P2WPKH | P2WSH (2-3) | P2TR  |
 |-------------------|-------|------------|--------|-------------|-------|
-| Overhead (b)      | 10    | 10         | 10     | 10          | 10    |
-| Input (b)         | 147   | 293        | 41     | 41          | 41    |
-| OP_RETURN (b)     | 11    | 11         | 14     | 14          | 14    |
-| Base size (b)     | 168   | 314        | 65     | 65          | 65    |
-| Witness data (b)  | 0     | 0          | 107    | 252         | 67    |
-| Size (b)          | 168   | 314        | 172    | 317         | 132   |
+| Overhead (B)      | 10    | 10         | 10     | 10          | 10    |
+| Input (B)         | 147   | 293        | 41     | 41          | 41    |
+| OP_RETURN (B)     | 11    | 11         | 14     | 14          | 14    |
+| Base size (B)     | 168   | 314        | 65     | 65          | 65    |
+| Witness data (B)  | 0     | 0          | 107    | 252         | 67    |
+| Size (B)          | 168   | 314        | 172    | 317         | 132   |
 | Weight (wu)       | 672   | 1256       | 369    | 514         | 329   |
-| Virtual Size (vb) | 168   | 314        | 92.25  | 128.5       | 82.25 |
+| Virtual Size (vB) | 168   | 314        | 92.25  | 128.5       | 82.25 |
 
 ECDSA-signed inputs assume low-R signature grinding (71-byte signatures including the sighash byte)
 
-#### Example dust disposal transaction fee rates (sats/vb)
+#### Example dust disposal transaction fee rates (sats/vB)
 
 | Input Amount | P2PKH   | P2SH (2-3) | P2WPKH | P2WSH (2-3) | P2TR  |
 |--------------|---------|------------|--------|-------------|-------|

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,31 @@ fn is_dust(out: &LocalOutput, dust_amount: &Amount) -> bool {
     !out.is_spent && out.txout.value <= *dust_amount && out.chain_position.is_confirmed()
 }
 
+struct CandidateTx {
+    tx: Transaction,
+    fee: Amount,
+    rate: f64,
+    input_vsize: f64,
+    has_segwit: bool,
+    legacy_count: usize,
+}
+
+impl CandidateTx {
+    fn new(tx: &Transaction, rpc_client: &Client) -> Self {
+        let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
+        let fee = entry.fees.base;
+        let rate = fee.to_sat() as f64 / entry.vsize as f64;
+        Self {
+            tx: tx.clone(),
+            fee,
+            rate,
+            input_vsize: tx.input.iter().map(get_input_vsize).sum(),
+            has_segwit: tx.input.iter().any(|i| !i.witness.is_empty()),
+            legacy_count: tx.input.iter().filter(|i| i.witness.is_empty()).count(),
+        }
+    }
+}
+
 /// Selects unconfirmed ddust transactions that can be batched into a single RBF-compliant replacement.
 /// `dust_utxos` are extra inputs added by the batcher.
 ///
@@ -694,117 +719,90 @@ fn find_batchable_txs(
     }
     let output_script = &unconfirmed_txs[0].output[0].script_pubkey;
 
-    let mut batchable: Vec<Transaction> = vec![];
-
-    // replacement tx vsize
-    // segwit-tx serialization adds two costs over a pure-legacy tx:
-    //   - 0.5 vb for the per-tx marker+flag (2 bytes, once)
-    //   - 0.25 vb per legacy (empty-witness)
-    // Both apply only if the replacement is segwit (any input has a witness).
+    // Initial replacement state from the batcher's own dust inputs. If any input is segwit,
+    // the tx pays a 0.5 vb marker+flag (once) plus 0.25 vb per legacy input.
     let mut has_segwit = dust_utxos
         .iter()
         .any(|u| u.txout.script_pubkey.is_witness_program());
-    let mut legacy_input_count = dust_utxos
+    let mut legacy_count = dust_utxos
         .iter()
         .filter(|u| !u.txout.script_pubkey.is_witness_program())
         .count();
-    let mut tx_vsize = 10.0;
-    if has_segwit {
-        tx_vsize += 0.5 + 0.25 * legacy_input_count as f64;
-    }
-    tx_vsize += dust_utxos
-        .iter()
-        .map(|utxo| estimate_input_vsize(&utxo.txout.script_pubkey))
-        .sum::<f64>();
-
-    tx_vsize += match output_script.as_bytes() {
-        // empty OP_RETURN no data, size = 11
-        [0x6a, 0x00] => 11.0,
-        // contains 3 bytes 'ash', size = 14
-        _ => 14.0,
+    let output_vsize = match output_script.as_bytes() {
+        [0x6a, 0x00] => 11.0, // empty OP_RETURN
+        _ => 14.0,            // "ash" OP_RETURN
     };
-
-    let tx_input_amount: Amount = dust_utxos.iter().map(|out| out.txout.value).sum();
-    let dust_amount_sats = tx_input_amount.to_sat() as f64;
-
-    // collect fee, rate, input vsize, segwit-presence and legacy-input count per unconfirmed tx
-    let mut tx_info: Vec<(Transaction, Amount, f64, f64, bool, usize)> = unconfirmed_txs
+    let dust_input_vsize: f64 = dust_utxos
         .iter()
-        .map(|tx| {
-            let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
-            let fee = entry.fees.base;
-            let vsize = entry.vsize as f64;
-            let rate = fee.to_sat() as f64 / vsize;
-            let input_vsize: f64 = tx.input.iter().map(get_input_vsize).sum();
-            let tx_has_segwit = tx.input.iter().any(|i| !i.witness.is_empty());
-            let tx_legacy_count = tx.input.iter().filter(|i| i.witness.is_empty()).count();
-            (
-                tx.clone(),
-                fee,
-                rate,
-                input_vsize,
-                tx_has_segwit,
-                tx_legacy_count,
-            )
-        })
+        .map(|u| estimate_input_vsize(&u.txout.script_pubkey))
+        .sum();
+    let segwit_vbytes = if has_segwit {
+        0.5 + 0.25 * legacy_count as f64
+    } else {
+        0.0
+    };
+    let mut combined_vsize = 10.0 + dust_input_vsize + output_vsize + segwit_vbytes;
+
+    let dust_amount: Amount = dust_utxos.iter().map(|u| u.txout.value).sum();
+    let dust_sats = dust_amount.to_sat() as f64;
+    let mut combined_amount = dust_amount;
+
+    // Sort ascending by fee rate: each iteration's rate check against `c.rate` covers all
+    // already-accepted txs, since their rates are <= the current one.
+    let mut candidates: Vec<CandidateTx> = unconfirmed_txs
+        .iter()
+        .map(|tx| CandidateTx::new(tx, rpc_client))
         .collect();
+    candidates.sort_by(|a, b| a.rate.partial_cmp(&b.rate).unwrap());
 
-    // sort ascending by fee rate so the rate check against the current iteration's rate
-    // covers all previously accepted txs (their rates are <= current).
-    tx_info.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-
-    // mempool eviction cap
+    // BIP125 caps replaced txs at 100.
     const MAX_REPLACED: usize = 100;
 
-    let mut combined_vsize: f64 = tx_vsize;
-    let mut combined_amount: Amount = tx_input_amount;
-
-    for (tx, fee, rate, input_vsize, tx_has_segwit, tx_legacy_count) in tx_info {
+    let mut batchable: Vec<Transaction> = vec![];
+    for c in candidates {
         if batchable.len() >= MAX_REPLACED {
             debug!("batchable: hit eviction cap of {} txs", MAX_REPLACED);
             break;
         }
-        // segwit serialization tax: 0.5 vb (marker+flag, once) + 0.25 vb per legacy input
-        let now_segwit = has_segwit || tx_has_segwit;
-        let mut overhead_bump = 0.0;
+
+        // Is the replacement a segwit tx after adding c?
+        let now_segwit = has_segwit || c.has_segwit;
+        let mut bump = 0.0;
+        // Just turned segwit: pay marker+flag once + 0.25 vb on each prior legacy input.
         if !has_segwit && now_segwit {
-            // segwit just turned on: pay marker+flag and 0.25 per already-counted legacy input
-            overhead_bump += 0.5 + 0.25 * legacy_input_count as f64;
+            bump += 0.5 + 0.25 * legacy_count as f64;
         }
+        // Segwit tx: each legacy input in c pays 0.25 vb for its empty witness counter.
         if now_segwit {
-            // each new legacy input from this tx pays the empty-witness-counter cost
-            overhead_bump += 0.25 * tx_legacy_count as f64;
+            bump += 0.25 * c.legacy_count as f64;
         }
-        let new_amount = combined_amount + fee;
-        let new_vsize = combined_vsize + input_vsize + overhead_bump;
+
+        let new_amount = combined_amount + c.fee;
+        let new_vsize = combined_vsize + c.input_vsize + bump;
         let new_rate = new_amount.to_sat() as f64 / new_vsize.ceil();
 
-        // additional fee (dust_amount_sats) must cover incremental relay over new vsize.
-        let bandwidth_ok = dust_amount_sats >= 0.1 * new_vsize.ceil();
-        // replacement rate must exceed every replaced tx's rate.
-        let rate_ok = new_rate > rate;
-
-        if bandwidth_ok && rate_ok {
-            debug!(
-                "batchable: adding tx (rate {:.3}, combined rate {:.3}, combined vsize {:.1})",
-                rate, new_rate, new_vsize
-            );
-            combined_amount = new_amount;
-            combined_vsize = new_vsize;
-            legacy_input_count += tx_legacy_count;
-            if tx_has_segwit {
-                has_segwit = true;
-            }
-            batchable.push(tx);
-        } else {
-            // sorted ascending by rate, so subsequent txs have rate >= this one (rate check
-            // gets harder) and add at least some vsize (bandwidth check gets harder).
+        // Replacement must (1) pay for its own bandwidth (0.1 sat/vB incremental relay)
+        // and (2) exceed every replaced tx's fee rate.
+        let bandwidth_ok = dust_sats >= 0.1 * new_vsize.ceil();
+        let rate_ok = new_rate > c.rate;
+        if !(bandwidth_ok && rate_ok) {
+            // Sorted ascending by rate, so subsequent txs only make both checks harder.
             debug!(
                 "batchable: stopping at rate {:.3} (bandwidth_ok={}, rate_ok={}, combined rate {:.3}, combined vsize {:.1})",
-                rate, bandwidth_ok, rate_ok, new_rate, new_vsize
+                c.rate, bandwidth_ok, rate_ok, new_rate, new_vsize
             );
             break;
         }
+
+        debug!(
+            "batchable: adding tx (rate {:.3}, combined rate {:.3}, combined vsize {:.1})",
+            c.rate, new_rate, new_vsize
+        );
+        combined_amount = new_amount;
+        combined_vsize = new_vsize;
+        legacy_count += c.legacy_count;
+        has_segwit = now_segwit;
+        batchable.push(c.tx);
     }
 
     batchable

--- a/src/main.rs
+++ b/src/main.rs
@@ -824,6 +824,7 @@ mod tests {
     use corepc_node::AddressType;
     use test_env::TestEnv;
 
+    #[derive(Clone, Copy)]
     enum OpReturn {
         Empty,
         Ash,
@@ -1134,148 +1135,321 @@ mod tests {
     fn min_sats_for_batching(
         orig_tx_fee: Amount,
         orig_tx_input_types: &[InputType],
+        orignal_has_ash: Option<bool>,
         replacement_tx_input_type: InputType,
     ) -> Amount {
         let mut orig_tx = TxSizeCalculator::new();
         for input_type in orig_tx_input_types {
             orig_tx = orig_tx.add_input(*input_type);
         }
-        let orig_tx_vsize = orig_tx.calculate().vsize.ceil();
+        // calculate() sees inputs as a standalone tx and can't tell a real multi-input
+        // spend (Empty) from a batching-grown replacement (preserve orig's Ash).
+        // orignal_has_ash forces the choice; None defers to calculate()'s rule.
+        let orig_breakdown = match orignal_has_ash {
+            Some(use_ash) => orig_tx.calculate_with_op_return(use_ash),
+            None => orig_tx.calculate(),
+        };
+        let orig_uses_ash = orig_breakdown.output_bytes == 14; // OP_RETURN_ASH
+        let orig_tx_vsize = orig_breakdown.vsize.ceil();
         let replacement_tx = orig_tx.add_input(replacement_tx_input_type);
-        let replacement_tx_vsize = replacement_tx.calculate().vsize.ceil();
+        let replacement_tx_vsize = replacement_tx
+            .calculate_with_op_return(orig_uses_ash)
+            .vsize
+            .ceil();
         let fee_rate = orig_tx_fee.to_sat() as f64 / orig_tx_vsize;
         // requires atleast `sats` at the fee rate of the original tx
-        let rate_min_sats = (fee_rate * replacement_tx_vsize) as u64 - orig_tx_fee.to_sat();
+        let rate_min_sats = (fee_rate * replacement_tx_vsize).ceil() as u64 - orig_tx_fee.to_sat();
         // requires `sats` that pay the replacement_vsize at the relay rate
-        let bandwidth_min_sats = (0.1 * replacement_tx_vsize) as u64;
+        let bandwidth_min_sats = (0.1 * replacement_tx_vsize).ceil() as u64;
         Amount::from_sat(bandwidth_min_sats.max(rate_min_sats))
     }
+    /// Sends `amt1_per_input` to a fresh `addr1_type` address `addr1_input_count` times so
+    /// the first ddust tx has the requested input count, then sends `min_sats + 1` to a
+    /// fresh `addr2_type` address. Spending addr2 should replace the first tx via batching
+    /// while preserving its OpReturn output.
+    fn run_batch_test(
+        addr1_type: &AddressType,
+        addr1_input: InputType,
+        addr1_input_count: usize,
+        amt1_per_input: Amount,
+        addr2_type: &AddressType,
+        addr2_input: InputType,
+        expected: OpReturn,
+    ) {
+        assert!(addr1_input_count >= 1, "addr1_input_count must be >= 1");
+        let ctx = setup_ctx();
+
+        let addr1 = ctx.env.new_address(&ctx.wallet1_name, addr1_type);
+        for _ in 0..addr1_input_count {
+            ctx.env.send_to_address(&addr1, amt1_per_input);
+        }
+
+        let addr2 = ctx.env.new_address(&ctx.wallet2_name, addr2_type);
+        let addr2_insufficient_sats = ctx.env.new_address(&ctx.wallet2_name, addr2_type);
+        // total fee paid by the first tx = sum of its dust inputs
+        let orig_fee = amt1_per_input * (addr1_input_count as u64);
+        let orig_inputs = vec![addr1_input; addr1_input_count];
+        let min_sats = min_sats_for_batching(orig_fee, &orig_inputs, None, addr2_input);
+        let amt2 = min_sats + Amount::ONE_SAT;
+        ctx.env.send_to_address(&addr2, amt2);
+        ctx.env
+            .send_to_address(&addr2_insufficient_sats, min_sats - Amount::ONE_SAT);
+        ctx.env.mine_blocks(1);
+
+        // dust threshold must include all UTXOs
+        let dust_sats = amt1_per_input.max(amt2);
+
+        // first tx
+        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
+        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
+        broadcast_and_assert(&ctx, signed, addr1_input_count, expected);
+
+        // spend `addr2_insufficient_sats`: insufficient fee, no batching
+        let psbt = cmd_spend(
+            &ctx.db,
+            ctx.network,
+            &ctx.rpc_client,
+            dust_sats,
+            addr2_insufficient_sats,
+        )
+        .unwrap();
+        assert_eq!(psbt.inputs.len(), 1);
+
+        // spend addr2 and expect batch of the mempool ddust tx (OpReturn preserved)
+        let psbt_batched =
+            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
+        let signed = ctx
+            .env
+            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
+        broadcast_and_assert(&ctx, signed, addr1_input_count + 1, expected);
+    }
+
     fn setup_ctx() -> TestContext {
         let ctx = TestContext::new();
 
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet1_name, &AddressType::Legacy);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet1_name, &AddressType::Bech32);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet1_name, &AddressType::Bech32m);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet2_name, &AddressType::Legacy);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet2_name, &AddressType::Bech32m);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
-        let desc = ctx
-            .env
-            .get_descriptor(&ctx.wallet2_name, &AddressType::Bech32);
-        cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
+        for wallet in [&ctx.wallet1_name, &ctx.wallet2_name] {
+            for addr_type in [
+                AddressType::Legacy,
+                AddressType::Bech32,
+                AddressType::Bech32m,
+            ] {
+                let desc = ctx.env.get_descriptor(wallet, &addr_type);
+                cmd_add(&ctx.secp, &ctx.db, ctx.network, &ctx.rpc_client, desc, 0);
+            }
+        }
 
         ctx
     }
 
-    /// OpReturn::Empty batch (Legacy + Bech32m)
+    /// OpReturn::Ash batch (Bech32m + Bech32m)
     #[test]
-    fn test_batch_legacy_bech32() {
-        let ctx = setup_ctx();
+    fn test_batch_bech32m_bech32m() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Ash,
+        );
+    }
 
-        // Case: Expect OpReturn::Empty
-        let addr1 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Legacy);
-        let amt1 = Amount::from_sat(555);
-        ctx.env.send_to_address(&addr1, amt1);
-        let addr2 = ctx
-            .env
-            .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let min_sats = min_sats_for_batching(amt1, &[InputType::P2PKH], InputType::P2WPKH);
-        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
-        ctx.env.mine_blocks(1);
-
-        // first tx
-        let dust_sats = Amount::from_sat(600);
-        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
-        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
-        broadcast_and_assert(&ctx, signed, 1, OpReturn::Empty);
-
-        // spend addr2 and expect batch of the mempool ddust tx
-        let psbt_batched =
-            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
-        let signed = ctx
-            .env
-            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the original tx output of OpReturn::Empty is preserved
-        broadcast_and_assert(&ctx, signed.clone(), 2, OpReturn::Empty);
+    /// OpReturn::Ash batch (Bech32m + Bech32): the Bech32m tx produces Ash as a single
+    /// witness input, and the Bech32 input batcher preserves it.
+    #[test]
+    fn test_batch_bech32m_bech32() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            OpReturn::Ash,
+        );
     }
 
     /// OpReturn::Ash batch (Bech32m + Legacy)
     #[test]
-    fn test_batch_bech32_legacy() {
-        let ctx = setup_ctx();
-
-        // Case: Expect OpReturn::Ash
-        let addr1 = ctx.env.new_address(&ctx.wallet1_name, &AddressType::Bech32);
-        let amt1 = Amount::from_sat(555);
-        ctx.env.send_to_address(&addr1, amt1);
-        let addr2 = ctx.env.new_address(&ctx.wallet2_name, &AddressType::Legacy);
-        let min_sats = min_sats_for_batching(amt1, &[InputType::P2WPKH], InputType::P2PKH);
-        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
-        ctx.env.mine_blocks(1);
-
-        // first tx
-        let dust_sats = Amount::from_sat(1000);
-        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
-        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
-        broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
-
-        // spend addr2 and expect batch of the mempool ddust tx
-        let psbt_batched =
-            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
-        let signed = ctx
-            .env
-            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the original tx output of OpReturn::Ash is preserved
-        broadcast_and_assert(&ctx, signed.clone(), 2, OpReturn::Ash);
+    fn test_batch_bech32m_legacy() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            OpReturn::Ash,
+        );
     }
 
-    /// OpReturn::Ash batch (Bech32m + Bech32m)
+    /// OpReturn::Ash batch (Bech32 + Bech32m)
+    #[test]
+    fn test_batch_bech32_bech32m() {
+        run_batch_test(
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Ash,
+        );
+    }
+
+    /// OpReturn::Ash batch (Bech32 + Bech32)
     #[test]
     fn test_batch_bech32_bech32() {
-        let ctx = setup_ctx();
+        run_batch_test(
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            OpReturn::Ash,
+        );
+    }
 
-        // Case: The first Bech32m spend outputs an OpReturn:Ash, the second Bech32m spend
-        // keeps op_return:Ash from the replaced tx
-        let addr1 = ctx
-            .env
-            .new_address(&ctx.wallet1_name, &AddressType::Bech32m);
-        let amt1 = Amount::from_sat(400);
-        ctx.env.send_to_address(&addr1, amt1);
-        let addr2 = ctx
-            .env
-            .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let min_sats = min_sats_for_batching(amt1, &[InputType::P2TR], InputType::P2TR);
-        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
-        ctx.env.mine_blocks(1);
+    /// OpReturn::Ash batch (Bech32 + Legacy)
+    #[test]
+    fn test_batch_bech32_legacy() {
+        run_batch_test(
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            1,
+            Amount::from_sat(400),
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            OpReturn::Ash,
+        );
+    }
 
-        // first tx: spend addr1
-        let dust_sats = Amount::from_sat(600);
-        let psbt = cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr1).unwrap();
-        let signed = ctx.env.wallet_process_psbt(&ctx.wallet1_name, &psbt);
-        broadcast_and_assert(&ctx, signed, 1, OpReturn::Ash);
+    /// OpReturn::Empty batch (Legacy + Bech32m)
+    #[test]
+    fn test_batch_legacy_bech32m() {
+        run_batch_test(
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            1,
+            Amount::from_sat(555),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Empty,
+        );
+    }
 
-        // spend addr2 and expect batch of the mempool ddust tx
-        let psbt_batched =
-            cmd_spend(&ctx.db, ctx.network, &ctx.rpc_client, dust_sats, addr2).unwrap();
-        let signed = ctx
-            .env
-            .wallet_process_psbt(&ctx.wallet2_name, &psbt_batched);
-        // the original tx output of OpReturn::Ash is preserved
-        broadcast_and_assert(&ctx, signed, 2, OpReturn::Ash);
+    /// OpReturn::Empty batch (Legacy + Bech32)
+    #[test]
+    fn test_batch_legacy_bech32() {
+        run_batch_test(
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            1,
+            Amount::from_sat(555),
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            OpReturn::Empty,
+        );
+    }
+
+    /// OpReturn::Empty batch (Legacy + Legacy)
+    #[test]
+    fn test_batch_legacy_legacy() {
+        run_batch_test(
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            1,
+            Amount::from_sat(555),
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 2x Bech32m + Bech32m batcher
+    #[test]
+    fn test_batch_2bech32m_bech32m() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            2,
+            Amount::from_sat(400),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 2x Bech32 + Bech32 batcher
+    #[test]
+    fn test_batch_2bech32_bech32() {
+        run_batch_test(
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            2,
+            Amount::from_sat(400),
+            &AddressType::Bech32,
+            InputType::P2WPKH,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 2x Legacy + Legacy batcher
+    #[test]
+    fn test_batch_2legacy_legacy() {
+        run_batch_test(
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            2,
+            Amount::from_sat(555),
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 2x Bech32m + Legacy batcher (mixed addr1/addr2 types)
+    #[test]
+    fn test_batch_2bech32m_legacy() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            2,
+            Amount::from_sat(400),
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 2x Legacy + Bech32m batcher (mixed; segwit-overhead bump adds up in batching)
+    #[test]
+    fn test_batch_2legacy_bech32m() {
+        run_batch_test(
+            &AddressType::Legacy,
+            InputType::P2PKH,
+            2,
+            Amount::from_sat(555),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Empty,
+        );
+    }
+
+    /// 3x Bech32m + Bech32m batcher
+    #[test]
+    fn test_batch_3bech32m_bech32m() {
+        run_batch_test(
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            3,
+            Amount::from_sat(400),
+            &AddressType::Bech32m,
+            InputType::P2TR,
+            OpReturn::Empty,
+        );
     }
 
     /// 3. No batching when fee rate is insufficient for RBF
@@ -1292,7 +1466,7 @@ mod tests {
         let addr2 = ctx
             .env
             .new_address(&ctx.wallet2_name, &AddressType::Bech32m);
-        let min_sats = min_sats_for_batching(amt1, &[InputType::P2WPKH], InputType::P2TR);
+        let min_sats = min_sats_for_batching(amt1, &[InputType::P2WPKH], None, InputType::P2TR);
         // send less than min_sats to prevent a valid RBF
         dbg!(min_sats);
         ctx.env.send_to_address(&addr2, min_sats - Amount::ONE_SAT);
@@ -1343,7 +1517,8 @@ mod tests {
         ctx.env.send_to_address(&addr1, amt1);
 
         // step 2 (new P2TR input): > min_sats_for_batching(tx1) batches the previous p2tr input.
-        let min_sats_p2tr_p2tr = min_sats_for_batching(amt1, &[InputType::P2TR], InputType::P2TR);
+        let min_sats_p2tr_p2tr =
+            min_sats_for_batching(amt1, &[InputType::P2TR], None, InputType::P2TR);
         let amt_batch_p2tr_p2tr = min_sats_p2tr_p2tr + Amount::ONE_SAT;
         ctx.env.send_to_address(&addr2, amt_batch_p2tr_p2tr);
 
@@ -1351,6 +1526,7 @@ mod tests {
         let min_sats_batchedp2tr_p2pkh = min_sats_for_batching(
             amt1 + amt_batch_p2tr_p2tr,
             &[InputType::P2TR, InputType::P2TR],
+            Some(true),
             InputType::P2PKH,
         );
         let amt_no_batch_2p2tr_p2pkh = min_sats_batchedp2tr_p2pkh - Amount::ONE_SAT;
@@ -1360,6 +1536,7 @@ mod tests {
         let min_sats_p2wpkh = min_sats_for_batching(
             amt_no_batch_2p2tr_p2pkh,
             &[InputType::P2PKH],
+            None,
             InputType::P2WPKH,
         );
         let amt_p2wpkh_no_batch = min_sats_p2wpkh - Amount::ONE_SAT;

--- a/src/main.rs
+++ b/src/main.rs
@@ -612,8 +612,9 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
                         return false;
                     }
                 }
-                // ECDSA (P2WPKH/P2WSH)
-                71..=73 => {
+                // ECDSA (P2WPKH/P2WSH) — low-R/low-S sigs (with sighash byte) are typically
+                // 71 B, but can be 70 when s has a leading 0x00, or 72 in non-grinded paths.
+                70..=73 => {
                     if *sig.last().unwrap() != EcdsaSighashType::AllPlusAnyoneCanPay as u8 {
                         return false;
                     }
@@ -638,6 +639,9 @@ fn is_ddust_tx(tx: &Transaction, want_script: &Option<Vec<u8>>) -> bool {
 }
 
 fn get_input_vsize(input: &TxIn) -> f64 {
+    if input.witness.is_empty() {
+        return input.base_size() as f64;
+    }
     let weight = input.base_size() * 3 + input.total_size();
     weight as f64 / 4.0
 }
@@ -646,18 +650,18 @@ fn estimate_input_vsize(script_pubkey: &ScriptBuf) -> f64 {
     if script_pubkey.is_p2tr() {
         57.75
     } else if script_pubkey.is_p2wpkh() {
-        68.0
+        67.75
     } else if script_pubkey.is_p2wsh() {
         // 2-of-3 multisig estimate
-        105.0
+        104.0
     } else if script_pubkey.is_p2pkh() {
-        148.0
+        147.0
     } else if script_pubkey.is_p2sh() {
         // Could be P2SH-P2WPKH (~364 WU)
         // Could be P2SH-P2WSH (~478 WU for 2-of-3)
-        // Could be bare P2SH multisig (~1188 WU for 2-of-3)
+        // Could be bare P2SH multisig (~1172 WU for 2-of-3)
         // Can't tell from scriptPubKey alone, use worst case
-        297.0
+        293.0
     } else {
         panic!("Unsupported input encountered");
     }
@@ -693,8 +697,21 @@ fn find_batchable_txs(
     let mut batchable: Vec<Transaction> = vec![];
 
     // replacement tx vsize
-    // overhead
-    let mut tx_vsize = 10.5;
+    // segwit-tx serialization adds two costs over a pure-legacy tx:
+    //   - 0.5 vb for the per-tx marker+flag (2 bytes, once)
+    //   - 0.25 vb per legacy (empty-witness)
+    // Both apply only if the replacement is segwit (any input has a witness).
+    let mut has_segwit = dust_utxos
+        .iter()
+        .any(|u| u.txout.script_pubkey.is_witness_program());
+    let mut legacy_input_count = dust_utxos
+        .iter()
+        .filter(|u| !u.txout.script_pubkey.is_witness_program())
+        .count();
+    let mut tx_vsize = 10.0;
+    if has_segwit {
+        tx_vsize += 0.5 + 0.25 * legacy_input_count as f64;
+    }
     tx_vsize += dust_utxos
         .iter()
         .map(|utxo| estimate_input_vsize(&utxo.txout.script_pubkey))
@@ -710,8 +727,8 @@ fn find_batchable_txs(
     let tx_input_amount: Amount = dust_utxos.iter().map(|out| out.txout.value).sum();
     let dust_amount_sats = tx_input_amount.to_sat() as f64;
 
-    // collect fee, rate and input vsize for each unconfirmed tx
-    let mut tx_info: Vec<(Transaction, Amount, f64, f64)> = unconfirmed_txs
+    // collect fee, rate, input vsize, segwit-presence and legacy-input count per unconfirmed tx
+    let mut tx_info: Vec<(Transaction, Amount, f64, f64, bool, usize)> = unconfirmed_txs
         .iter()
         .map(|tx| {
             let entry = rpc_client.get_mempool_entry(&tx.compute_txid()).unwrap();
@@ -719,7 +736,16 @@ fn find_batchable_txs(
             let vsize = entry.vsize as f64;
             let rate = fee.to_sat() as f64 / vsize;
             let input_vsize: f64 = tx.input.iter().map(get_input_vsize).sum();
-            (tx.clone(), fee, rate, input_vsize)
+            let tx_has_segwit = tx.input.iter().any(|i| !i.witness.is_empty());
+            let tx_legacy_count = tx.input.iter().filter(|i| i.witness.is_empty()).count();
+            (
+                tx.clone(),
+                fee,
+                rate,
+                input_vsize,
+                tx_has_segwit,
+                tx_legacy_count,
+            )
         })
         .collect();
 
@@ -733,17 +759,28 @@ fn find_batchable_txs(
     let mut combined_vsize: f64 = tx_vsize;
     let mut combined_amount: Amount = tx_input_amount;
 
-    for (tx, fee, rate, input_vsize) in tx_info {
+    for (tx, fee, rate, input_vsize, tx_has_segwit, tx_legacy_count) in tx_info {
         if batchable.len() >= MAX_REPLACED {
             debug!("batchable: hit eviction cap of {} txs", MAX_REPLACED);
             break;
         }
+        // segwit serialization tax: 0.5 vb (marker+flag, once) + 0.25 vb per legacy input
+        let now_segwit = has_segwit || tx_has_segwit;
+        let mut overhead_bump = 0.0;
+        if !has_segwit && now_segwit {
+            // segwit just turned on: pay marker+flag and 0.25 per already-counted legacy input
+            overhead_bump += 0.5 + 0.25 * legacy_input_count as f64;
+        }
+        if now_segwit {
+            // each new legacy input from this tx pays the empty-witness-counter cost
+            overhead_bump += 0.25 * tx_legacy_count as f64;
+        }
         let new_amount = combined_amount + fee;
-        let new_vsize = combined_vsize + input_vsize;
-        let new_rate = new_amount.to_sat() as f64 / new_vsize;
+        let new_vsize = combined_vsize + input_vsize + overhead_bump;
+        let new_rate = new_amount.to_sat() as f64 / new_vsize.ceil();
 
         // additional fee (dust_amount_sats) must cover incremental relay over new vsize.
-        let bandwidth_ok = dust_amount_sats >= 0.1 * new_vsize;
+        let bandwidth_ok = dust_amount_sats >= 0.1 * new_vsize.ceil();
         // replacement rate must exceed every replaced tx's rate.
         let rate_ok = new_rate > rate;
 
@@ -754,6 +791,10 @@ fn find_batchable_txs(
             );
             combined_amount = new_amount;
             combined_vsize = new_vsize;
+            legacy_input_count += tx_legacy_count;
+            if tx_has_segwit {
+                has_segwit = true;
+            }
             batchable.push(tx);
         } else {
             // sorted ascending by rate, so subsequent txs have rate >= this one (rate check
@@ -1183,7 +1224,7 @@ mod tests {
         ctx.env.send_to_address(&addr1, amt1);
         let addr2 = ctx.env.new_address(&ctx.wallet2_name, &AddressType::Legacy);
         let min_sats = min_sats_for_batching(amt1, &[InputType::P2WPKH], InputType::P2PKH);
-        ctx.env.send_to_address(&addr2, min_sats);
+        ctx.env.send_to_address(&addr2, min_sats + Amount::ONE_SAT);
         ctx.env.mine_blocks(1);
 
         // first tx

--- a/src/test_calc.rs
+++ b/src/test_calc.rs
@@ -149,7 +149,7 @@ impl TxSizeCalculator {
             Self::OVERHEAD + Self::input_base_size(&self.inputs[0]) + Self::OP_RETURN_EMPTY;
         let needs_ash = first_input_base_with_empty < Self::MIN_BASE_SIZE;
 
-        let output_bytes = if needs_ash {
+        let output_bytes = if needs_ash && self.inputs.len() == 1 {
             Self::OP_RETURN_ASH
         } else {
             Self::OP_RETURN_EMPTY
@@ -202,12 +202,23 @@ impl TxSizeCalculator {
     ) -> TxSizeBreakdown {
         let base_size = Self::OVERHEAD + input_base + output_bytes;
         let witness_overhead = if has_witness { Self::WITNESS_HEADER } else { 0 };
-        let total_size = base_size + witness_overhead + input_witness;
+
+        // segwit tx: each legacy input pays 1 byte for its empty witness-stack counter
+        let legacy_input_count = if has_witness {
+            self.inputs
+                .iter()
+                .filter(|i| Self::input_witness_size(i) == 0)
+                .count()
+        } else {
+            0
+        };
+
+        let total_size = base_size + witness_overhead + input_witness + legacy_input_count;
 
         // Weight calculation:
         // - Base data (non-witness) counts as 4 weight units per byte
         // - Witness data counts as 1 weight unit per byte
-        let weight = base_size * 4 + witness_overhead + input_witness;
+        let weight = base_size * 4 + witness_overhead + input_witness + legacy_input_count;
         let vsize = weight as f64 / 4.0;
 
         TxSizeBreakdown {
@@ -226,8 +237,8 @@ impl TxSizeCalculator {
     fn input_base_size(input_type: &InputType) -> usize {
         match input_type {
             // P2PKH: outpoint (36) + scriptSig length (1) + scriptSig (~107) + sequence (4)
-            // scriptSig: sig (~72) + pubkey (33) + push opcodes (2)
-            InputType::P2PKH => 148,
+            // scriptSig: sig (~71) + pubkey (33) + push opcodes (2)
+            InputType::P2PKH => 147,
 
             // P2WPKH: outpoint (36) + empty scriptSig (1) + sequence (4)
             InputType::P2WPKH => 41,
@@ -255,8 +266,8 @@ impl TxSizeCalculator {
             // P2PKH: no witness data
             InputType::P2PKH => 0,
 
-            // P2WPKH witness: item count (1) + sig length (1) + sig (~72) + pubkey length (1) + pubkey (33)
-            InputType::P2WPKH => 108,
+            // P2WPKH witness: item count (1) + sig length (1) + sig (~71) + pubkey length (1) + pubkey (33)
+            InputType::P2WPKH => 107,
 
             // P2TR witness (key-path): item count (1) + sig length (1) + schnorr sig (64) + sighash type (1)
             // Note: NONE|ANYONECANPAY requires explicit sighash byte
@@ -266,7 +277,7 @@ impl TxSizeCalculator {
                 // Bare P2SH multisig: no witness
                 P2SHInner::Multisig(_) => 0,
                 // P2SH-P2WPKH: same witness as P2WPKH
-                P2SHInner::P2WPKH => 108,
+                P2SHInner::P2WPKH => 107,
                 // P2SH-P2WSH: multisig witness
                 P2SHInner::P2WSH(cfg) => Self::p2wsh_witness_size(cfg),
             },
@@ -282,7 +293,7 @@ impl TxSizeCalculator {
         // sequence: 4 bytes
         // scriptSig contains:
         //   - OP_0 (CHECKMULTISIG bug workaround): 1 byte
-        //   - m signatures: m * (push opcode 1 + sig ~72) = m * 73
+        //   - m signatures: m * (push opcode 1 + sig ~72) = m * 72
         //   - redeemScript push: 1 byte (OP_PUSHDATA1) + 1 byte (length) for scripts > 75 bytes
         //   - redeemScript: OP_m (1) + n * (push 1 + pubkey 33) + OP_n (1) + OP_CHECKMULTISIG (1)
         //                 = 3 + n * 34
@@ -291,7 +302,7 @@ impl TxSizeCalculator {
         let redeem_script_push = if redeem_script_size > 75 { 2 } else { 1 };
 
         // scriptSig = OP_0 + m * (push + sig) + redeemScript push + redeemScript
-        let scriptsig_size = 1 + cfg.required * 73 + redeem_script_push + redeem_script_size;
+        let scriptsig_size = 1 + cfg.required * 72 + redeem_script_push + redeem_script_size;
         let scriptsig_len_varint = Self::varint_size(scriptsig_size);
 
         36 + scriptsig_len_varint + scriptsig_size + 4
@@ -302,7 +313,7 @@ impl TxSizeCalculator {
         // Witness stack:
         //   - item count: varint (1 byte for small counts)
         //   - OP_0 dummy for CHECKMULTISIG bug: length (1) + empty (0) = 1 byte
-        //   - m signatures: m * (length varint 1 + sig ~72) = m * 73
+        //   - m signatures: m * (length varint 1 + sig ~72) = m * 72
         //   - witness script: length varint + script
         //     script = OP_m (1) + n * (push 1 + pubkey 33) + OP_n (1) + OP_CHECKMULTISIG (1)
         //            = 3 + n * 34
@@ -311,7 +322,7 @@ impl TxSizeCalculator {
         let witness_script_len_varint = Self::varint_size(witness_script_size);
 
         // item count (1) + OP_0 dummy (1) + m signatures + witness script
-        1 + 1 + cfg.required * 73 + witness_script_len_varint + witness_script_size
+        1 + 1 + cfg.required * 72 + witness_script_len_varint + witness_script_size
     }
 
     /// Calculate VarInt size for a given value
@@ -341,16 +352,16 @@ mod tests {
             .calculate();
 
         // From BIP spec table: P2PKH single input
-        // Overhead: 10, Input: 148, OP_RETURN: 11 (empty)
-        // Base size: 169, Weight: 676, vSize: 169
+        // Overhead: 10, Input: 147, OP_RETURN: 11 (empty)
+        // Base size: 168, Weight: 672, vSize: 168
         assert_eq!(size.overhead_bytes, 10);
-        assert_eq!(size.input_base_bytes, 148);
+        assert_eq!(size.input_base_bytes, 147);
         assert_eq!(size.input_witness_bytes, 0);
         assert_eq!(size.output_bytes, 11); // empty OP_RETURN (no padding needed)
-        assert_eq!(size.base_size, 169);
-        assert_eq!(size.total_size, 169);
-        assert_eq!(size.weight, 676);
-        assert_eq!(size.vsize, 169.0);
+        assert_eq!(size.base_size, 168);
+        assert_eq!(size.total_size, 168);
+        assert_eq!(size.weight, 672);
+        assert_eq!(size.vsize, 168.0);
         assert!(size.meets_min_size());
     }
 
@@ -362,17 +373,17 @@ mod tests {
 
         // From BIP spec table: P2WPKH single input
         // Overhead: 10, Input base: 41, OP_RETURN: 14 (ash for padding)
-        // Base size: 65, Witness: 108, Total: 175, Weight: 370, vSize: 92.5
+        // Base size: 65, Witness: 107, Total: 174, Weight: 369, vSize: 92.25
         assert_eq!(size.overhead_bytes, 10);
         assert_eq!(size.input_base_bytes, 41);
-        assert_eq!(size.input_witness_bytes, 108);
+        assert_eq!(size.input_witness_bytes, 107);
         assert_eq!(size.output_bytes, 14); // "ash" OP_RETURN (needs padding)
         assert_eq!(size.base_size, 65);
-        // total = base + witness_header (2) + witness = 65 + 2 + 108 = 175
-        assert_eq!(size.total_size, 175);
-        // weight = base * 4 + witness_header + witness = 65*4 + 2 + 108 = 370
-        assert_eq!(size.weight, 370);
-        assert_eq!(size.vsize, 92.5);
+        // total = base + witness_header (2) + witness = 65 + 2 + 107 = 174
+        assert_eq!(size.total_size, 174);
+        // weight = base * 4 + witness_header + witness = 65*4 + 2 + 107 = 369
+        assert_eq!(size.weight, 369);
+        assert_eq!(size.vsize, 92.25);
         assert!(size.meets_min_size());
     }
 
@@ -410,9 +421,9 @@ mod tests {
 
         // 2-of-2 P2SH multisig:
         // redeemScript = OP_2 + 2*(push + pubkey) + OP_2 + OP_CHECKMULTISIG = 3 + 2*34 = 71 bytes
-        // scriptSig = OP_0 + 2*(push + sig) + push + redeemScript = 1 + 2*73 + 1 + 71 = 219
-        // input = 36 + 1 + 219 + 4 = 260
-        assert_eq!(size.input_base_bytes, 260);
+        // scriptSig = OP_0 + 2*(push + sig) + push + redeemScript = 1 + 2*72 + 1 + 71 = 217
+        // input = 36 + 1 + 217 + 4 = 258
+        assert_eq!(size.input_base_bytes, 258);
         assert_eq!(size.input_witness_bytes, 0);
         assert_eq!(size.output_bytes, 11); // empty (base size > 65)
         assert!(size.meets_min_size());
@@ -428,10 +439,10 @@ mod tests {
 
         // 2-of-3 P2SH multisig:
         // redeemScript = 3 + 3*34 = 105 bytes (> 75, needs OP_PUSHDATA1)
-        // scriptSig = OP_0 + 2*73 + 2 + 105 = 254 bytes
-        // scriptSig length varint = 3 bytes (since 254 >= 253)
-        // input = 36 + 3 + 254 + 4 = 297
-        assert_eq!(size.input_base_bytes, 297);
+        // scriptSig = OP_0 + 2*72 + 2 + 105 = 252 bytes
+        // scriptSig length varint = 1 bytes (since 252 < 253)
+        // input = 36 + 1 + 252 + 4 = 293
+        assert_eq!(size.input_base_bytes, 293);
         assert_eq!(size.input_witness_bytes, 0);
         assert!(size.meets_min_size());
     }
@@ -445,15 +456,15 @@ mod tests {
         // P2WSH 2-of-3:
         // input base: 41
         // witness script = 3 + 3*34 = 105 bytes
-        // witness = 1 (count) + 1 (OP_0) + 2*73 (sigs) + 1 (len) + 105 = 254
+        // witness = 1 (count) + 1 (OP_0) + 2*72 (sigs) + 1 (len) + 105 = 252
         assert_eq!(size.input_base_bytes, 41);
-        assert_eq!(size.input_witness_bytes, 254);
+        assert_eq!(size.input_witness_bytes, 252);
         assert_eq!(size.output_bytes, 14); // "ash" (single witness input)
         assert!(size.meets_min_size());
 
-        // weight = 65*4 + 2 + 254 = 516
-        assert_eq!(size.weight, 516);
-        assert_eq!(size.vsize, 129.0);
+        // weight = 65*4 + 2 + 252 = 514
+        assert_eq!(size.weight, 514);
+        assert_eq!(size.vsize, 128.5);
     }
 
     #[test]
@@ -464,15 +475,15 @@ mod tests {
 
         // P2SH-P2WPKH (nested SegWit):
         // input base: 64 (36 + 1 + 23 + 4)
-        // witness: 108 (same as P2WPKH)
+        // witness: 107 (same as P2WPKH)
         assert_eq!(size.input_base_bytes, 64);
-        assert_eq!(size.input_witness_bytes, 108);
+        assert_eq!(size.input_witness_bytes, 107);
         assert_eq!(size.output_bytes, 11); // empty (base = 10+64+11 = 85 >= 65)
         assert!(size.meets_min_size());
 
-        // weight = 85*4 + 2 + 108 = 450
-        assert_eq!(size.weight, 450);
-        assert_eq!(size.vsize, 112.5);
+        // weight = 85*4 + 2 + 107 = 449
+        assert_eq!(size.weight, 449);
+        assert_eq!(size.vsize, 112.25);
     }
 
     #[test]
@@ -483,9 +494,9 @@ mod tests {
 
         // P2SH-P2WSH 2-of-3:
         // input base: 76 (36 + 1 + 35 + 4)
-        // witness = 1 + 1 + 2*73 + 1 + 105 = 254
+        // witness = 1 + 1 + 2*72 + 1 + 105 = 252
         assert_eq!(size.input_base_bytes, 76);
-        assert_eq!(size.input_witness_bytes, 254);
+        assert_eq!(size.input_witness_bytes, 252);
         assert_eq!(size.output_bytes, 11); // empty (base = 10+76+11 = 97 >= 65)
         assert!(size.meets_min_size());
     }
@@ -512,7 +523,7 @@ mod tests {
             .add_input(InputType::P2TR)
             .calculate();
 
-        assert_eq!(size.input_base_bytes, 189); // 148 + 41
+        assert_eq!(size.input_base_bytes, 188); // 147 + 41
         assert_eq!(size.input_witness_bytes, 67); // 0 + 67
         assert_eq!(size.output_bytes, 11); // empty (multiple inputs)
     }
@@ -607,7 +618,7 @@ mod tests {
         let p2wpkh = TxSizeCalculator::new()
             .add_input(InputType::P2WPKH)
             .calculate();
-        assert!((p2wpkh.fee_rate(300) - 3.24).abs() < 0.01);
+        assert!((p2wpkh.fee_rate(300) - 3.25).abs() < 0.01);
 
         let p2tr = TxSizeCalculator::new()
             .add_input(InputType::P2TR)
@@ -623,17 +634,17 @@ mod tests {
         assert_eq!(TxSizeCalculator::single_input_vsize(InputType::P2TR), 57.75);
         assert_eq!(
             TxSizeCalculator::single_input_vsize(InputType::P2WPKH),
-            68.0
+            67.75
         );
         assert_eq!(
             TxSizeCalculator::single_input_vsize(InputType::P2PKH),
-            148.0
+            147.0
         );
 
-        // P2WSH 2-of-3: (41*4 + 254) / 4 = 104.5
+        // P2WSH 2-of-3: (41*4 + 252) / 4 = 104.0
         let p2wsh_vsize =
             TxSizeCalculator::single_input_vsize(InputType::P2WSH(MultisigConfig::new(2, 3)));
-        assert_eq!(p2wsh_vsize, 104.5);
+        assert_eq!(p2wsh_vsize, 104.0);
     }
 
     #[test]
@@ -644,8 +655,8 @@ mod tests {
 
         // Combined input vsize
         let vsize = calc.input_vsize();
-        // P2PKH: 148, P2TR: 57.75, total: 205.75
-        assert_eq!(vsize, 205.75);
+        // P2PKH: 147, P2TR: 57.75, total: 204.75
+        assert_eq!(vsize, 204.75);
     }
 
     // ==================== BIP Spec Table Verification ====================
@@ -658,17 +669,17 @@ mod tests {
         let p2pkh = TxSizeCalculator::new()
             .add_input(InputType::P2PKH)
             .calculate();
-        assert_eq!(p2pkh.base_size, 169);
-        assert_eq!(p2pkh.weight, 676);
-        assert_eq!(p2pkh.vsize, 169.0);
+        assert_eq!(p2pkh.base_size, 168);
+        assert_eq!(p2pkh.weight, 672);
+        assert_eq!(p2pkh.vsize, 168.0);
 
         // P2WPKH
         let p2wpkh = TxSizeCalculator::new()
             .add_input(InputType::P2WPKH)
             .calculate();
         assert_eq!(p2wpkh.base_size, 65);
-        assert_eq!(p2wpkh.weight, 370);
-        assert_eq!(p2wpkh.vsize, 92.5);
+        assert_eq!(p2wpkh.weight, 369);
+        assert_eq!(p2wpkh.vsize, 92.25);
 
         // P2TR
         let p2tr = TxSizeCalculator::new()
@@ -727,7 +738,7 @@ mod tests {
             .add_input(InputType::P2PKH)
             .calculate();
 
-        assert_eq!(first_tx.vsize, 169.0); // 10.5 rounded to 10 for overhead
+        assert_eq!(first_tx.vsize, 168.0); // 10.5 rounded to 10 for overhead
 
         // For batching, we need to calculate the combined size
         let batched = TxSizeCalculator::new()

--- a/src/test_calc.rs
+++ b/src/test_calc.rs
@@ -145,11 +145,11 @@ impl TxSizeCalculator {
 
         // Check if we need "ash" padding to meet minimum size
         // Only single witness inputs need padding
-        let first_input_base_with_empty =
-            Self::OVERHEAD + Self::input_base_size(&self.inputs[0]) + Self::OP_RETURN_EMPTY;
-        let needs_ash = first_input_base_with_empty < Self::MIN_BASE_SIZE;
+        let base_with_empty = Self::OVERHEAD + input_base + Self::OP_RETURN_EMPTY;
+        let needs_ash =
+            self.inputs.len() == 1 && has_witness && base_with_empty < Self::MIN_BASE_SIZE;
 
-        let output_bytes = if needs_ash && self.inputs.len() == 1 {
+        let output_bytes = if needs_ash {
             Self::OP_RETURN_ASH
         } else {
             Self::OP_RETURN_EMPTY
@@ -504,16 +504,26 @@ mod tests {
     // ==================== Multiple Input Tests ====================
 
     #[test]
-    fn test_multiple_p2tr_inputs_preserves_ash() {
+    fn test_multiple_p2tr_inputs_use_empty() {
         let size = TxSizeCalculator::new()
             .add_input(InputType::P2TR)
             .add_input(InputType::P2TR)
             .calculate();
 
         // Multiple inputs always use empty OP_RETURN
-        assert_eq!(size.output_bytes, 14);
+        assert_eq!(size.output_bytes, 11);
         assert_eq!(size.input_base_bytes, 82); // 41 * 2
         assert_eq!(size.input_witness_bytes, 134); // 67 * 2
+    }
+
+    #[test]
+    fn test_calculate_with_op_return_preserves_ash_for_multi_input() {
+        let size = TxSizeCalculator::new()
+            .add_input(InputType::P2TR)
+            .add_input(InputType::P2TR)
+            .calculate_with_op_return(true);
+
+        assert_eq!(size.output_bytes, 14);
     }
 
     #[test]


### PR DESCRIPTION
fixes #23 

- Account for low-R grinded ECDSA signatures (71B) and the 1-byte empty witness counter each legacy input incurs in a segwit tx.
- Fix min_sats_for_batching to preserve the orig's OP_RETURN; refactor find_batchable_txs.
- Add batching combinations and multi-input replacement test scenarios.