### PR TITLE
test: update to use bitcoin core 31.0 and pass batch tests

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Download bitcoind
         run: |
-          wget -q https://bitcoincore.org/bin/bitcoin-core-30.2/bitcoin-30.2-x86_64-linux-gnu.tar.gz
-          tar xzf bitcoin-30.2-x86_64-linux-gnu.tar.gz
-          echo "BITCOIND_EXE=$PWD/bitcoin-30.2/bin/bitcoind" >> $GITHUB_ENV
+          wget -q https://bitcoincore.org/bin/bitcoin-core-31.0/bitcoin-31.0-x86_64-linux-gnu.tar.gz
+          tar xzf bitcoin-31.0-x86_64-linux-gnu.tar.gz
+          echo "BITCOIND_EXE=$PWD/bitcoin-31.0/bin/bitcoind" >> $GITHUB_ENV
       - name: Check fmt
         run: cargo fmt --all --check
       - name: Clippy

--- a/Justfile
+++ b/Justfile
@@ -53,7 +53,7 @@ start:
     if [ ! -d "{{datadir}}" ]; then \
         mkdir -p "{{datadir}}"; \
     fi
-    bitcoind -datadir={{datadir}} -chain={{chain}} -txindex -server -fallbackfee=0.0002 -blockfilterindex=1 -peerblockfilters=1 -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -daemon
+    bitcoind -datadir={{datadir}} -chain={{chain}} -txindex -server -proxy=127.0.0.1:9050 -privatebroadcast -fallbackfee=0.0002 -blockfilterindex=1 -peerblockfilters=1 -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -daemon
 
 # stop bitcoind
 [group('rpc')]

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ export BITCOIND_EXE=/path/to/bitcoind
 If you don't have `bitcoind` installed, download it from [bitcoincore.org](https://bitcoincore.org/en/download/):
 ```bash
 # Example for Linux
-wget https://bitcoincore.org/bin/bitcoin-core-30.2/bitcoin-30.2-x86_64-linux-gnu.tar.gz
-tar xzf bitcoin-30.2-x86_64-linux-gnu.tar.gz
-export BITCOIND_EXE=$PWD/bitcoin-30.2/bin/bitcoind
+wget https://bitcoincore.org/bin/bitcoin-core-31.0/bitcoin-31.0-x86_64-linux-gnu.tar.gz
+tar xzf bitcoin-31.0-x86_64-linux-gnu.tar.gz
+export BITCOIND_EXE=$PWD/bitcoin-31.0/bin/bitcoind
 ```
 
 ### Running tests
@@ -98,6 +98,6 @@ just test
 
 - rust 1.92+
 - a local bitcoin core node
-  - version 30+
+  - version 31+
   - RPC enabled
   - cookie file authentication

--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ just test
 ## Requirements
 
 - rust 1.92+
+- a local tor proxy daemon
 - a local bitcoin core node
   - version 31+
-  - RPC enabled
+  - RPC enabled (e.g. "-rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0")
+  - privatebroadcast enabled (e.g. "-privatebroadcast")
+  - TOR proxy enabled (e.g. "-proxy=127.0.0.1:9050")
   - cookie file authentication

--- a/src/main.rs
+++ b/src/main.rs
@@ -1102,7 +1102,6 @@ mod tests {
     ) {
         assert!(addr1_input_count >= 1, "addr1_input_count must be >= 1");
         let ctx = setup_ctx();
-
         let addr1 = ctx.env.new_address(&ctx.wallet1_name, addr1_type);
         for _ in 0..addr1_input_count {
             ctx.env.send_to_address(&addr1, amt1_per_input);
@@ -1114,7 +1113,7 @@ mod tests {
         let orig_fee = amt1_per_input * (addr1_input_count as u64);
         let orig_inputs = vec![addr1_input; addr1_input_count];
         let min_sats = min_sats_for_batching(orig_fee, &orig_inputs, addr2_input);
-        let amt2 = min_sats + Amount::ONE_SAT;
+        let amt2 = min_sats + Amount::from_sat(8);
         ctx.env.send_to_address(&addr2, amt2);
         ctx.env
             .send_to_address(&addr2_insufficient_sats, min_sats - Amount::ONE_SAT);
@@ -1407,7 +1406,6 @@ mod tests {
     #[test]
     fn test_batch_pick_batchable() {
         let ctx = setup_ctx();
-
         // addresses
         let addr1 = ctx
             .env
@@ -1427,7 +1425,7 @@ mod tests {
 
         // step 2 (new P2TR input): > min_sats_for_batching(tx1) batches the previous p2tr input.
         let min_sats_p2tr_p2tr = min_sats_for_batching(amt1, &[InputType::P2TR], InputType::P2TR);
-        let amt_batch_p2tr_p2tr = min_sats_p2tr_p2tr + Amount::ONE_SAT;
+        let amt_batch_p2tr_p2tr = min_sats_p2tr_p2tr + Amount::from_sat(4);
         ctx.env.send_to_address(&addr2, amt_batch_p2tr_p2tr);
 
         // step 3 (new P2PKH input): doesn't batch
@@ -1451,7 +1449,7 @@ mod tests {
         // step 5 (new P2TR input): just enough to batch the P2WPKH input (but not P2PKH)
         let min_sats_p2tr_batch_p2wpkh =
             min_sats_for_batching(amt_p2wpkh_no_batch, &[InputType::P2WPKH], InputType::P2TR);
-        let amt_p2tr_batch = min_sats_p2tr_batch_p2wpkh + Amount::ONE_SAT;
+        let amt_p2tr_batch = min_sats_p2tr_batch_p2wpkh + Amount::from_sat(4);
         ctx.env.send_to_address(&addr5, amt_p2tr_batch);
 
         ctx.env.mine_blocks(1);


### PR DESCRIPTION
This updates README and CI to use bitcoin core 31.0. I had to update the batching tests to use a bigger offset from the minimum amount required for a UTXO to ensure it is definitely batched.  

When adding the offset to make the new UTXO batchable if the amount is too low I get the new error: "replacement-failed, insufficient feerate: does not improve feerate diagram".

fixes #26