### PR TITLE
ci: cache bitcoind and rust dependencies 

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,11 +16,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Cache bitcoind
+        id: cache-bitcoind
+        uses: actions/cache@v5
+        with:
+          path: bitcoin-31.0
+          key: ${{ runner.os }}-bitcoind
       - name: Download bitcoind
+        if: steps.cache-bitcoind.outputs.cache-hit != 'true'
         run: |
           wget -q https://bitcoincore.org/bin/bitcoin-core-31.0/bitcoin-31.0-x86_64-linux-gnu.tar.gz
           tar xzf bitcoin-31.0-x86_64-linux-gnu.tar.gz
-          echo "BITCOIND_EXE=$PWD/bitcoin-31.0/bin/bitcoind" >> $GITHUB_ENV
+      - name: Set BITCOIND_EXE env
+        run: echo "BITCOIND_EXE=$PWD/bitcoin-31.0/bin/bitcoind" >> $GITHUB_ENV
       - name: Check fmt
         run: cargo fmt --all --check
       - name: Clippy

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Cache bitcoind
         id: cache-bitcoind
         uses: actions/cache@v5


### PR DESCRIPTION
This only saves about 8 seconds (was 10s now 2s) for the download and unzip bitcoind. But I still think it's worth it not putting the extra load on the core bitcoin CDNs. 

I also added caching for the rust dependencies at that speeds up the build significantly.

fixes #18 